### PR TITLE
获取当前毫秒数替换

### DIFF
--- a/nacos-spring-samples/nacos-embedded-webserver/src/main/java/com/alibaba/nacos/embedded/web/server/NacosConfigHttpHandler.java
+++ b/nacos-spring-samples/nacos-embedded-webserver/src/main/java/com/alibaba/nacos/embedded/web/server/NacosConfigHttpHandler.java
@@ -84,7 +84,7 @@ public class NacosConfigHttpHandler implements HttpHandler {
                             if (longPolling == null) {
                                 continue;
                             }
-                            if (new Date().getTime() - longPolling.date.getTime() > (maxWaitInSecond * 1000L)) {
+                            if (System.currentTimeMillis() - longPolling.date.getTime() > (maxWaitInSecond * 1000L)) {
                                 try {
                                     write(longPolling.httpExchange, "");
                                 } catch (IOException e) {


### PR DESCRIPTION
小马哥，看源码时候idea，无意间被扫描这个代码有修改意见，“获取当前毫秒数：System.currentTimeMillis(); 而不是new Date().getTime(); 说明：如果想获取更加精确的纳秒级时间值，用System.nanoTime”，知道你平时很忙，就顺手帮你改了下，你看这样的建议是可取的嘛，哈哈