### PR TITLE
[Optimization] Enhance the precedence of @NacosPropertySource process

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Complete the following steps to enable Nacos for your Spring project.
 	        <dependency>
 	            <groupId>com.alibaba.nacos</groupId>
 	            <artifactId>nacos-spring-context</artifactId>
-	            <version>0.1.0-RC1</version>
+	            <version>0.1.0-RC2</version>
 	        </dependency>
 	        
 	        ...

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Complete the following steps to enable Nacos for your Spring project.
 	        <dependency>
 	            <groupId>com.alibaba.nacos</groupId>
 	            <artifactId>nacos-spring-context</artifactId>
-	            <version>0.1.0-RC2</version>
+	            <version>0.1.0-RC1</version>
 	        </dependency>
 	        
 	        ...

--- a/nacos-spring-context/pom.xml
+++ b/nacos-spring-context/pom.xml
@@ -5,14 +5,14 @@
     <parent>
         <artifactId>nacos-spring-parent</artifactId>
         <groupId>com.alibaba.nacos</groupId>
-        <version>0.1.0-RC1</version>
+        <version>0.1.0-RC2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.alibaba.nacos</groupId>
     <artifactId>nacos-spring-context</artifactId>
-    <version>0.1.0-RC1</version>
+    <version>0.1.0-RC2</version>
     <name>Alibaba Nacos :: Spring :: Context</name>
     <packaging>jar</packaging>
 

--- a/nacos-spring-context/pom.xml
+++ b/nacos-spring-context/pom.xml
@@ -5,14 +5,14 @@
     <parent>
         <artifactId>nacos-spring-parent</artifactId>
         <groupId>com.alibaba.nacos</groupId>
-        <version>0.1.0-RC2</version>
+        <version>0.1.0-RC1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.alibaba.nacos</groupId>
     <artifactId>nacos-spring-context</artifactId>
-    <version>0.1.0-RC2</version>
+    <version>0.1.0-RC1</version>
     <name>Alibaba Nacos :: Spring :: Context</name>
     <packaging>jar</packaging>
 

--- a/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/context/annotation/NacosBeanDefinitionRegistrar.java
+++ b/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/context/annotation/NacosBeanDefinitionRegistrar.java
@@ -16,9 +16,6 @@
  */
 package com.alibaba.nacos.spring.context.annotation;
 
-import org.springframework.beans.BeansException;
-import org.springframework.beans.factory.BeanFactory;
-import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
@@ -29,12 +26,7 @@ import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.env.Environment;
 import org.springframework.core.type.AnnotationMetadata;
 
-import static com.alibaba.nacos.spring.util.NacosBeanUtils.GLOBAL_NACOS_PROPERTIES_BEAN_NAME;
-import static com.alibaba.nacos.spring.util.NacosBeanUtils.invokeNacosPropertySourcePostProcessor;
-import static com.alibaba.nacos.spring.util.NacosBeanUtils.registerGlobalNacosProperties;
-import static com.alibaba.nacos.spring.util.NacosBeanUtils.registerNacosCommonBeans;
-import static com.alibaba.nacos.spring.util.NacosBeanUtils.registerNacosConfigBeans;
-import static com.alibaba.nacos.spring.util.NacosBeanUtils.registerNacosDiscoveryBeans;
+import static com.alibaba.nacos.spring.util.NacosBeanUtils.*;
 
 /**
  * Nacos Properties {@link ImportBeanDefinitionRegistrar BeanDefinition Registrar}
@@ -43,11 +35,9 @@ import static com.alibaba.nacos.spring.util.NacosBeanUtils.registerNacosDiscover
  * @see EnableNacos
  * @since 0.1.0
  */
-public class NacosBeanDefinitionRegistrar implements ImportBeanDefinitionRegistrar, EnvironmentAware, BeanFactoryAware {
+public class NacosBeanDefinitionRegistrar implements ImportBeanDefinitionRegistrar, EnvironmentAware {
 
     private Environment environment;
-
-    private BeanFactory beanFactory;
 
     @Override
     public void registerBeanDefinitions(AnnotationMetadata importingClassMetadata, BeanDefinitionRegistry registry) {
@@ -60,11 +50,8 @@ public class NacosBeanDefinitionRegistrar implements ImportBeanDefinitionRegistr
 
         // Register Global Nacos Properties Bean
         registerGlobalNacosProperties(attributes, registry, environment, GLOBAL_NACOS_PROPERTIES_BEAN_NAME);
-        // Register Nacos Annotation Beans
+
         registerNacosAnnotationBeans(registry);
-        // Invoke NacosPropertySourcePostProcessor immediately
-        // in order to enhance the precedence of @NacosPropertySource process
-        invokeNacosPropertySourcePostProcessor(beanFactory);
     }
 
     @Override
@@ -76,10 +63,5 @@ public class NacosBeanDefinitionRegistrar implements ImportBeanDefinitionRegistr
         registerNacosCommonBeans(registry);
         registerNacosConfigBeans(registry, environment);
         registerNacosDiscoveryBeans(registry);
-    }
-
-    @Override
-    public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
-        this.beanFactory = beanFactory;
     }
 }

--- a/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/context/annotation/config/NacosConfigBeanDefinitionRegistrar.java
+++ b/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/context/annotation/config/NacosConfigBeanDefinitionRegistrar.java
@@ -17,6 +17,10 @@
 package com.alibaba.nacos.spring.context.annotation.config;
 
 import com.alibaba.nacos.spring.util.NacosBeanUtils;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.context.EnvironmentAware;
 import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
@@ -25,7 +29,11 @@ import org.springframework.core.env.Environment;
 import org.springframework.core.env.PropertyResolver;
 import org.springframework.core.type.AnnotationMetadata;
 
-import static com.alibaba.nacos.spring.util.NacosBeanUtils.*;
+import static com.alibaba.nacos.spring.util.NacosBeanUtils.CONFIG_GLOBAL_NACOS_PROPERTIES_BEAN_NAME;
+import static com.alibaba.nacos.spring.util.NacosBeanUtils.invokeNacosPropertySourcePostProcessor;
+import static com.alibaba.nacos.spring.util.NacosBeanUtils.registerGlobalNacosProperties;
+import static com.alibaba.nacos.spring.util.NacosBeanUtils.registerNacosCommonBeans;
+import static com.alibaba.nacos.spring.util.NacosBeanUtils.registerNacosConfigBeans;
 import static org.springframework.core.annotation.AnnotationAttributes.fromMap;
 
 /**
@@ -38,9 +46,12 @@ import static org.springframework.core.annotation.AnnotationAttributes.fromMap;
  * @see NacosBeanUtils#registerNacosConfigBeans(BeanDefinitionRegistry, Environment)
  * @since 0.1.0
  */
-public class NacosConfigBeanDefinitionRegistrar implements ImportBeanDefinitionRegistrar, EnvironmentAware {
+public class NacosConfigBeanDefinitionRegistrar implements ImportBeanDefinitionRegistrar, EnvironmentAware,
+        BeanFactoryAware {
 
     private Environment environment;
+
+    private BeanFactory beanFactory;
 
     @Override
     public void registerBeanDefinitions(AnnotationMetadata metadata, BeanDefinitionRegistry registry) {
@@ -51,10 +62,18 @@ public class NacosConfigBeanDefinitionRegistrar implements ImportBeanDefinitionR
         registerNacosCommonBeans(registry);
         // Register Nacos Config Beans
         registerNacosConfigBeans(registry, environment);
+        // Invoke NacosPropertySourcePostProcessor immediately
+        // in order to enhance the precedence of @NacosPropertySource process
+        invokeNacosPropertySourcePostProcessor(beanFactory);
     }
 
     @Override
     public void setEnvironment(Environment environment) {
         this.environment = environment;
+    }
+
+    @Override
+    public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
+        this.beanFactory = beanFactory;
     }
 }

--- a/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/context/annotation/config/NacosConfigBeanDefinitionRegistrar.java
+++ b/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/context/annotation/config/NacosConfigBeanDefinitionRegistrar.java
@@ -17,10 +17,6 @@
 package com.alibaba.nacos.spring.context.annotation.config;
 
 import com.alibaba.nacos.spring.util.NacosBeanUtils;
-
-import org.springframework.beans.BeansException;
-import org.springframework.beans.factory.BeanFactory;
-import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.context.EnvironmentAware;
 import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
@@ -29,11 +25,7 @@ import org.springframework.core.env.Environment;
 import org.springframework.core.env.PropertyResolver;
 import org.springframework.core.type.AnnotationMetadata;
 
-import static com.alibaba.nacos.spring.util.NacosBeanUtils.CONFIG_GLOBAL_NACOS_PROPERTIES_BEAN_NAME;
-import static com.alibaba.nacos.spring.util.NacosBeanUtils.invokeNacosPropertySourcePostProcessor;
-import static com.alibaba.nacos.spring.util.NacosBeanUtils.registerGlobalNacosProperties;
-import static com.alibaba.nacos.spring.util.NacosBeanUtils.registerNacosCommonBeans;
-import static com.alibaba.nacos.spring.util.NacosBeanUtils.registerNacosConfigBeans;
+import static com.alibaba.nacos.spring.util.NacosBeanUtils.*;
 import static org.springframework.core.annotation.AnnotationAttributes.fromMap;
 
 /**
@@ -46,12 +38,9 @@ import static org.springframework.core.annotation.AnnotationAttributes.fromMap;
  * @see NacosBeanUtils#registerNacosConfigBeans(BeanDefinitionRegistry, Environment)
  * @since 0.1.0
  */
-public class NacosConfigBeanDefinitionRegistrar implements ImportBeanDefinitionRegistrar, EnvironmentAware,
-        BeanFactoryAware {
+public class NacosConfigBeanDefinitionRegistrar implements ImportBeanDefinitionRegistrar, EnvironmentAware {
 
     private Environment environment;
-
-    private BeanFactory beanFactory;
 
     @Override
     public void registerBeanDefinitions(AnnotationMetadata metadata, BeanDefinitionRegistry registry) {
@@ -62,18 +51,10 @@ public class NacosConfigBeanDefinitionRegistrar implements ImportBeanDefinitionR
         registerNacosCommonBeans(registry);
         // Register Nacos Config Beans
         registerNacosConfigBeans(registry, environment);
-        // Invoke NacosPropertySourcePostProcessor immediately
-        // in order to enhance the precedence of @NacosPropertySource process
-        invokeNacosPropertySourcePostProcessor(beanFactory);
     }
 
     @Override
     public void setEnvironment(Environment environment) {
         this.environment = environment;
-    }
-
-    @Override
-    public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
-        this.beanFactory = beanFactory;
     }
 }

--- a/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/core/env/NacosPropertySourcePostProcessor.java
+++ b/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/core/env/NacosPropertySourcePostProcessor.java
@@ -22,11 +22,11 @@ import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.spring.beans.factory.annotation.ConfigServiceBeanBuilder;
 import com.alibaba.nacos.spring.context.annotation.config.NacosPropertySources;
 import com.alibaba.nacos.spring.context.config.xml.NacosPropertySourceXmlBeanDefinition;
-
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor;
 import org.springframework.context.EnvironmentAware;
 import org.springframework.context.annotation.ConfigurationClassPostProcessor;
@@ -39,10 +39,8 @@ import org.springframework.core.env.PropertySources;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import static com.alibaba.nacos.spring.util.NacosBeanUtils.getConfigServiceBeanBuilder;
 import static com.alibaba.nacos.spring.util.NacosUtils.DEFAULT_STRING_ATTRIBUTE_VALUE;
@@ -63,20 +61,23 @@ import static org.springframework.util.ObjectUtils.nullSafeEquals;
  * @see BeanDefinitionRegistryPostProcessor
  * @since 0.1.0
  */
-public class NacosPropertySourcePostProcessor implements BeanFactoryPostProcessor, EnvironmentAware, Ordered {
+public class NacosPropertySourcePostProcessor implements BeanDefinitionRegistryPostProcessor, BeanFactoryPostProcessor,
+        EnvironmentAware, Ordered {
 
     /**
      * The bean name of {@link NacosPropertySourcePostProcessor}
      */
     public static final String BEAN_NAME = "nacosPropertySourcePostProcessor";
 
-    private final Set<String> processedBeanNames = new LinkedHashSet<String>();
-
     private ConfigurableEnvironment environment;
 
     private Collection<AbstractNacosPropertySourceBuilder> nacosPropertySourceBuilders;
 
     private ConfigServiceBeanBuilder configServiceBeanBuilder;
+
+    @Override
+    public void postProcessBeanDefinitionRegistry(BeanDefinitionRegistry registry) throws BeansException {
+    }
 
     @Override
     public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {
@@ -94,10 +95,6 @@ public class NacosPropertySourcePostProcessor implements BeanFactoryPostProcesso
 
     private void processPropertySource(String beanName, ConfigurableListableBeanFactory beanFactory) {
 
-        if (processedBeanNames.contains(beanName)) { // If processed , return immediately.
-            return;
-        }
-
         BeanDefinition beanDefinition = beanFactory.getBeanDefinition(beanName);
         // Build multiple instance if possible
         List<NacosPropertySource> nacosPropertySources = buildNacosPropertySources(beanName, beanDefinition);
@@ -107,8 +104,6 @@ public class NacosPropertySourcePostProcessor implements BeanFactoryPostProcesso
             addNacosPropertySource(nacosPropertySource);
             addListenerIfAutoRefreshed(nacosPropertySource);
         }
-
-        processedBeanNames.add(beanName);
 
     }
 

--- a/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/core/env/NacosPropertySourcePostProcessor.java
+++ b/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/core/env/NacosPropertySourcePostProcessor.java
@@ -22,6 +22,7 @@ import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.spring.beans.factory.annotation.ConfigServiceBeanBuilder;
 import com.alibaba.nacos.spring.context.annotation.config.NacosPropertySources;
 import com.alibaba.nacos.spring.context.config.xml.NacosPropertySourceXmlBeanDefinition;
+
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
@@ -39,8 +40,10 @@ import org.springframework.core.env.PropertySources;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static com.alibaba.nacos.spring.util.NacosBeanUtils.getConfigServiceBeanBuilder;
 import static com.alibaba.nacos.spring.util.NacosUtils.DEFAULT_STRING_ATTRIBUTE_VALUE;
@@ -69,6 +72,8 @@ public class NacosPropertySourcePostProcessor implements BeanDefinitionRegistryP
      */
     public static final String BEAN_NAME = "nacosPropertySourcePostProcessor";
 
+    private final Set<String> processedBeanNames = new LinkedHashSet<String>();
+
     private ConfigurableEnvironment environment;
 
     private Collection<AbstractNacosPropertySourceBuilder> nacosPropertySourceBuilders;
@@ -95,7 +100,12 @@ public class NacosPropertySourcePostProcessor implements BeanDefinitionRegistryP
 
     private void processPropertySource(String beanName, ConfigurableListableBeanFactory beanFactory) {
 
+        if (processedBeanNames.contains(beanName)) {
+            return;
+        }
+
         BeanDefinition beanDefinition = beanFactory.getBeanDefinition(beanName);
+
         // Build multiple instance if possible
         List<NacosPropertySource> nacosPropertySources = buildNacosPropertySources(beanName, beanDefinition);
 
@@ -105,6 +115,7 @@ public class NacosPropertySourcePostProcessor implements BeanDefinitionRegistryP
             addListenerIfAutoRefreshed(nacosPropertySource);
         }
 
+        processedBeanNames.add(beanName);
     }
 
     private List<NacosPropertySource> buildNacosPropertySources(String beanName, BeanDefinition beanDefinition) {

--- a/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/util/NacosBeanUtils.java
+++ b/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/util/NacosBeanUtils.java
@@ -34,6 +34,7 @@ import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.beans.factory.config.SingletonBeanRegistry;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
@@ -332,6 +333,17 @@ public abstract class NacosBeanUtils {
         registerConfigServiceBeanBuilder(registry);
 
         registerLoggingNacosConfigMetadataEventListener(registry);
+    }
+
+    /**
+     * Invokes {@link NacosPropertySourcePostProcessor}
+     *
+     * @param beanFactory {@link BeanFactory}
+     */
+    public static void invokeNacosPropertySourcePostProcessor(BeanFactory beanFactory) {
+        NacosPropertySourcePostProcessor postProcessor =
+                beanFactory.getBean(NacosPropertySourcePostProcessor.BEAN_NAME, NacosPropertySourcePostProcessor.class);
+        postProcessor.postProcessBeanFactory((ConfigurableListableBeanFactory) beanFactory);
     }
 
     /**

--- a/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/util/NacosBeanUtils.java
+++ b/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/util/NacosBeanUtils.java
@@ -29,13 +29,11 @@ import com.alibaba.nacos.spring.core.env.XmlNacosPropertySourceBuilder;
 import com.alibaba.nacos.spring.factory.CacheableEventPublishingNacosServiceFactory;
 import com.alibaba.nacos.spring.factory.NacosServiceFactory;
 import com.alibaba.spring.util.BeanUtils;
-
 import org.apache.commons.lang3.ArrayUtils;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.config.BeanDefinition;
-import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.beans.factory.config.SingletonBeanRegistry;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
@@ -334,17 +332,6 @@ public abstract class NacosBeanUtils {
         registerConfigServiceBeanBuilder(registry);
 
         registerLoggingNacosConfigMetadataEventListener(registry);
-    }
-
-    /**
-     * Invokes {@link NacosPropertySourcePostProcessor}
-     *
-     * @param beanFactory {@link BeanFactory}
-     */
-    public static void invokeNacosPropertySourcePostProcessor(BeanFactory beanFactory) {
-        NacosPropertySourcePostProcessor postProcessor =
-                beanFactory.getBean(NacosPropertySourcePostProcessor.BEAN_NAME, NacosPropertySourcePostProcessor.class);
-        postProcessor.postProcessBeanFactory((ConfigurableListableBeanFactory) beanFactory);
     }
 
     /**

--- a/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/util/NacosBeanUtils.java
+++ b/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/util/NacosBeanUtils.java
@@ -29,11 +29,13 @@ import com.alibaba.nacos.spring.core.env.XmlNacosPropertySourceBuilder;
 import com.alibaba.nacos.spring.factory.CacheableEventPublishingNacosServiceFactory;
 import com.alibaba.nacos.spring.factory.NacosServiceFactory;
 import com.alibaba.spring.util.BeanUtils;
+
 import org.apache.commons.lang3.ArrayUtils;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.beans.factory.config.SingletonBeanRegistry;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
@@ -332,6 +334,17 @@ public abstract class NacosBeanUtils {
         registerConfigServiceBeanBuilder(registry);
 
         registerLoggingNacosConfigMetadataEventListener(registry);
+    }
+
+    /**
+     * Invokes {@link NacosPropertySourcePostProcessor}
+     *
+     * @param beanFactory {@link BeanFactory}
+     */
+    public static void invokeNacosPropertySourcePostProcessor(BeanFactory beanFactory) {
+        NacosPropertySourcePostProcessor postProcessor =
+                beanFactory.getBean(NacosPropertySourcePostProcessor.BEAN_NAME, NacosPropertySourcePostProcessor.class);
+        postProcessor.postProcessBeanFactory((ConfigurableListableBeanFactory) beanFactory);
     }
 
     /**

--- a/nacos-spring-samples/nacos-embedded-webserver/pom.xml
+++ b/nacos-spring-samples/nacos-embedded-webserver/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>nacos-spring-parent</artifactId>
         <groupId>com.alibaba.nacos</groupId>
-        <version>0.1.0-RC2</version>
+        <version>0.1.0-RC1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nacos-spring-samples/nacos-embedded-webserver/pom.xml
+++ b/nacos-spring-samples/nacos-embedded-webserver/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>nacos-spring-parent</artifactId>
         <groupId>com.alibaba.nacos</groupId>
-        <version>0.1.0-RC1</version>
+        <version>0.1.0-RC2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nacos-spring-samples/nacos-spring-webmvc-sample/pom.xml
+++ b/nacos-spring-samples/nacos-spring-webmvc-sample/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>nacos-spring-samples</artifactId>
         <groupId>com.alibaba.nacos</groupId>
-        <version>0.1.0-RC1</version>
+        <version>0.1.0-RC2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nacos-spring-samples/nacos-spring-webmvc-sample/pom.xml
+++ b/nacos-spring-samples/nacos-spring-webmvc-sample/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>nacos-spring-samples</artifactId>
         <groupId>com.alibaba.nacos</groupId>
-        <version>0.1.0-RC2</version>
+        <version>0.1.0-RC1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nacos-spring-samples/pom.xml
+++ b/nacos-spring-samples/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>nacos-spring-parent</artifactId>
         <groupId>com.alibaba.nacos</groupId>
-        <version>0.1.0-RC2</version>
+        <version>0.1.0-RC1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nacos-spring-samples/pom.xml
+++ b/nacos-spring-samples/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>nacos-spring-parent</artifactId>
         <groupId>com.alibaba.nacos</groupId>
-        <version>0.1.0-RC1</version>
+        <version>0.1.0-RC2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>com.alibaba.nacos</groupId>
     <artifactId>nacos-spring-parent</artifactId>
-    <version>0.1.0-RC2</version>
+    <version>0.1.0-RC1</version>
     <name>Alibaba Nacos :: Spring :: POM</name>
     <packaging>pom</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>com.alibaba.nacos</groupId>
     <artifactId>nacos-spring-parent</artifactId>
-    <version>0.1.0-RC1</version>
+    <version>0.1.0-RC2</version>
     <name>Alibaba Nacos :: Spring :: POM</name>
     <packaging>pom</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <sonar.jacoco.itReportPath>${project.basedir}/../test/target/jacoco-it.exec</sonar.jacoco.itReportPath>
         <sonar.exclusions>file:**/generated-sources/**,**/test/**</sonar.exclusions>
         <!-- Nacos -->
-        <nacos.version>0.5.0</nacos.version>
+        <nacos.version>0.2.1-RC1</nacos.version>
         <!-- Spring -->
         <spring.framework.version>3.2.18.RELEASE</spring.framework.version>
         <!-- Servlet -->

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <sonar.jacoco.itReportPath>${project.basedir}/../test/target/jacoco-it.exec</sonar.jacoco.itReportPath>
         <sonar.exclusions>file:**/generated-sources/**,**/test/**</sonar.exclusions>
         <!-- Nacos -->
-        <nacos.version>0.2.1-RC1</nacos.version>
+        <nacos.version>0.5.0</nacos.version>
         <!-- Spring -->
         <spring.framework.version>3.2.18.RELEASE</spring.framework.version>
         <!-- Servlet -->


### PR DESCRIPTION
`NacosPropertySourcePostProcessor` process a  `@NacosPropertySource`  to be `NacosPropertySource`. However, it's too late to append `NacosPropertySource` into `PropertySources` so that some Spring Bean can't use it.

Issue #70 