### PR TITLE
Fixes #72

### DIFF
--- a/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/beans/factory/annotation/AnnotationNacosInjectedBeanPostProcessor.java
+++ b/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/beans/factory/annotation/AnnotationNacosInjectedBeanPostProcessor.java
@@ -65,9 +65,15 @@ public class AnnotationNacosInjectedBeanPostProcessor extends AnnotationInjected
 
         Class<AbstractNacosServiceBeanBuilder> builderClass = AbstractNacosServiceBeanBuilder.class;
 
+        String[] beanNames = BeanUtils.getBeanNames(beanFactory, builderClass);
+        if (beanNames.length == 0) {
+            throw new NoSuchBeanDefinitionException(builderClass,
+                format("Please check the BeanDefinition of %s in Spring BeanFactory", builderClass));
+        }
+
         Collection<AbstractNacosServiceBeanBuilder> serviceBeanBuilders
-            = new ArrayList<AbstractNacosServiceBeanBuilder>(2);
-        for (String beanName : BeanUtils.getBeanNames(beanFactory, builderClass)) {
+            = new ArrayList<AbstractNacosServiceBeanBuilder>(beanNames.length);
+        for (String beanName : beanNames) {
             serviceBeanBuilders.add(beanFactory.getBean(beanName, builderClass));
         }
 

--- a/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/beans/factory/annotation/AnnotationNacosInjectedBeanPostProcessor.java
+++ b/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/beans/factory/annotation/AnnotationNacosInjectedBeanPostProcessor.java
@@ -20,11 +20,13 @@ import com.alibaba.nacos.api.annotation.NacosInjected;
 import com.alibaba.nacos.api.config.ConfigService;
 import com.alibaba.nacos.api.naming.NamingService;
 import com.alibaba.spring.beans.factory.annotation.AnnotationInjectedBeanPostProcessor;
+import com.alibaba.spring.util.BeanUtils;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.annotation.InjectionMetadata;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -52,7 +54,7 @@ public class AnnotationNacosInjectedBeanPostProcessor extends AnnotationInjected
     private Map<Class<?>, AbstractNacosServiceBeanBuilder> nacosServiceBeanBuilderMap;
 
     @Override
-    public final void afterPropertiesSet() throws Exception {
+    public final void afterPropertiesSet() {
         // Get beanFactory from super
         ConfigurableListableBeanFactory beanFactory = getBeanFactory();
 
@@ -63,8 +65,11 @@ public class AnnotationNacosInjectedBeanPostProcessor extends AnnotationInjected
 
         Class<AbstractNacosServiceBeanBuilder> builderClass = AbstractNacosServiceBeanBuilder.class;
 
-        Collection<AbstractNacosServiceBeanBuilder> serviceBeanBuilders =
-                beanFactory.getBeansOfType(builderClass).values();
+        Collection<AbstractNacosServiceBeanBuilder> serviceBeanBuilders
+            = new ArrayList<AbstractNacosServiceBeanBuilder>(2);
+        for (String beanName : BeanUtils.getBeanNames(beanFactory, builderClass)) {
+            serviceBeanBuilders.add(beanFactory.getBean(beanName, builderClass));
+        }
 
         if (serviceBeanBuilders.isEmpty()) {
             throw new NoSuchBeanDefinitionException(builderClass,
@@ -85,7 +90,7 @@ public class AnnotationNacosInjectedBeanPostProcessor extends AnnotationInjected
 
     @Override
     protected Object doGetInjectedBean(NacosInjected annotation, Object bean, String beanName, Class<?> injectedType,
-                                       InjectionMetadata.InjectedElement injectedElement) throws Exception {
+                                       InjectionMetadata.InjectedElement injectedElement) {
 
         AbstractNacosServiceBeanBuilder serviceBeanBuilder = nacosServiceBeanBuilderMap.get(injectedType);
 

--- a/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/core/env/NacosPropertySourcePostProcessor.java
+++ b/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/core/env/NacosPropertySourcePostProcessor.java
@@ -88,9 +88,13 @@ public class NacosPropertySourcePostProcessor implements BeanDefinitionRegistryP
 
     @Override
     public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {
-        this.nacosPropertySourceBuilders = new ArrayList<AbstractNacosPropertySourceBuilder>(2);
+        String[] abstractNacosPropertySourceBuilderBeanNames = BeanUtils.getBeanNames(beanFactory,
+            AbstractNacosPropertySourceBuilder.class);
 
-        for (String beanName : BeanUtils.getBeanNames(beanFactory, AbstractNacosPropertySourceBuilder.class)) {
+        this.nacosPropertySourceBuilders = new ArrayList<AbstractNacosPropertySourceBuilder>(
+            abstractNacosPropertySourceBuilderBeanNames.length);
+
+        for (String beanName : abstractNacosPropertySourceBuilderBeanNames) {
             this.nacosPropertySourceBuilders.add(
                 beanFactory.getBean(beanName, AbstractNacosPropertySourceBuilder.class));
         }

--- a/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/core/env/NacosPropertySourcePostProcessor.java
+++ b/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/core/env/NacosPropertySourcePostProcessor.java
@@ -23,6 +23,7 @@ import com.alibaba.nacos.spring.beans.factory.annotation.ConfigServiceBeanBuilde
 import com.alibaba.nacos.spring.context.annotation.config.NacosPropertySources;
 import com.alibaba.nacos.spring.context.config.xml.NacosPropertySourceXmlBeanDefinition;
 
+import com.alibaba.spring.util.BeanUtils;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
@@ -38,6 +39,7 @@ import org.springframework.core.env.Environment;
 import org.springframework.core.env.MutablePropertySources;
 import org.springframework.core.env.PropertySources;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -86,8 +88,13 @@ public class NacosPropertySourcePostProcessor implements BeanDefinitionRegistryP
 
     @Override
     public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {
+        this.nacosPropertySourceBuilders = new ArrayList<AbstractNacosPropertySourceBuilder>(2);
 
-        this.nacosPropertySourceBuilders = beanFactory.getBeansOfType(AbstractNacosPropertySourceBuilder.class).values();
+        for (String beanName : BeanUtils.getBeanNames(beanFactory, AbstractNacosPropertySourceBuilder.class)) {
+            this.nacosPropertySourceBuilders.add(
+                beanFactory.getBean(beanName, AbstractNacosPropertySourceBuilder.class));
+        }
+
         this.configServiceBeanBuilder = getConfigServiceBeanBuilder(beanFactory);
 
         String[] beanNames = beanFactory.getBeanDefinitionNames();


### PR DESCRIPTION
"ListableBeanFactory.getBeansOfType" will trigger some beans to be initialized before the configuration from Nacos is loaded.

For example, when using both Druid and Mybatis, the mapper class is initialized during nacos-spring-context loading.