### PR TITLE
Fix 33

### DIFF
--- a/nacos-spring-context/pom.xml
+++ b/nacos-spring-context/pom.xml
@@ -30,6 +30,13 @@
             <artifactId>spring-context</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>1.23</version>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- Spring Context Extras -->
         <dependency>
             <groupId>com.alibaba.spring</groupId>

--- a/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/context/annotation/config/NacosPropertySource.java
+++ b/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/context/annotation/config/NacosPropertySource.java
@@ -20,6 +20,7 @@ import com.alibaba.nacos.api.annotation.NacosProperties;
 import com.alibaba.nacos.api.common.Constants;
 import com.alibaba.nacos.spring.context.annotation.EnableNacos;
 import com.alibaba.nacos.spring.util.NacosUtils;
+import com.alibaba.nacos.spring.convert.converter.NacosPropertySourceConverter;
 import org.springframework.core.env.PropertySource;
 
 import java.lang.annotation.*;
@@ -82,6 +83,8 @@ public @interface NacosPropertySource {
      * The attribute name of {@link NacosPropertySource#properties()}
      */
     String PROPERTIES_ATTRIBUTE_NAME = "properties";
+
+    String CONVERTER_ATTRIBUTE_NAME = "converter";
 
     /**
      * The name of Nacos {@link PropertySource}
@@ -154,5 +157,8 @@ public @interface NacosPropertySource {
      */
     NacosProperties properties() default @NacosProperties;
 
-
+    /**
+     * @return a converter's Class for convert original string to properties string.
+     */
+    Class<? extends NacosPropertySourceConverter> converter() default NacosPropertySourceConverter.SimplePropertiesConverter.class;
 }

--- a/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/convert/converter/NacosPropertySourceConverter.java
+++ b/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/convert/converter/NacosPropertySourceConverter.java
@@ -1,0 +1,122 @@
+package com.alibaba.nacos.spring.convert.converter;
+
+import org.springframework.util.StringUtils;
+import org.yaml.snakeyaml.Yaml;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * @author hylexus
+ * Created At 2019-06-13 11:05
+ */
+public interface NacosPropertySourceConverter {
+
+    /**
+     * {yaml | json | plainText} --> properties-based string.
+     * examples:<br/>
+     * Input (yml-based string):
+     * <pre>
+     * a:
+     *   b: 1
+     *   c: 2
+     * </pre>
+     * Output (properties-based string):
+     * <pre>
+     *  a.b=1
+     *  a.c=2
+     * </pre>
+     *
+     * @param contentFromConfigServer original config from config-server
+     * @return converted value
+     */
+    String convert(String contentFromConfigServer);
+
+    class SimplePropertiesConverter implements NacosPropertySourceConverter {
+        @Override
+        public String convert(String contentFromConfigServer) {
+            return contentFromConfigServer;
+        }
+    }
+
+    /**
+     * A built-in Converter from yaml-based string to properties-based string.
+     * Main logic was copied from {@link org.springframework.beans.factory.config.YamlProcessor#buildFlattenedMap(java.util.Map, java.util.Map, java.lang.String)}
+     * <p>
+     * Github Address : https://github.com/spring-projects/spring-framework/blob/5.1.x/spring-beans/src/main/java/org/springframework/beans/factory/config/YamlProcessor.java
+     *
+     * @author Dave Syer
+     * @author Juergen Hoeller
+     * @author hylexus
+     */
+    class SimpleYamlConverter implements NacosPropertySourceConverter {
+
+        @Override
+        public String convert(String contentFromConfigServer) {
+            Properties properties = yamlStringToProperties(contentFromConfigServer);
+
+            StringBuilder stringBuilder = new StringBuilder();
+            for (Map.Entry entry : properties.entrySet()) {
+                stringBuilder.append(entry.getKey()).append("=").append(entry.getValue()).append("\n");
+            }
+
+            return stringBuilder.toString();
+        }
+
+        private Properties yamlStringToProperties(String yamlString) {
+            final Properties result = new Properties();
+            final Yaml yaml = new Yaml();
+            @SuppressWarnings("unchecked") final Map<String, Map<String, Object>> map = yaml.loadAs(yamlString, Map.class);
+            for (Map.Entry<String, Map<String, Object>> e : map.entrySet()) {
+                buildFlattenedMap(result, e.getValue(), e.getKey());
+            }
+
+            return result;
+        }
+
+        /**
+         * @author Dave Syer
+         * @author Juergen Hoeller
+         */
+        private void buildFlattenedMap(Properties result, Map<String, Object> source, String path) {
+            for (Map.Entry<String, Object> entry : source.entrySet()) {
+                String key = entry.getKey();
+                Object value = entry.getValue();
+
+                if (StringUtils.hasText(path)) {
+                    if (key.startsWith("[")) {
+                        key = path + key;
+                    } else {
+                        key = path + '.' + key;
+                    }
+                }
+                if (value instanceof String) {
+                    result.put(key, value);
+                } else if (value instanceof Map) {
+                    // Need a compound key
+                    @SuppressWarnings("unchecked")
+                    Map<String, Object> map = (Map<String, Object>) value;
+                    buildFlattenedMap(result, map, key);
+                } else if (value instanceof Collection) {
+                    // Need a compound key
+                    @SuppressWarnings("unchecked")
+                    Collection<Object> collection = (Collection<Object>) value;
+                    if (collection.isEmpty()) {
+                        result.put(key, "");
+                    } else {
+                        int count = 0;
+                        for (Object object : collection) {
+                            buildFlattenedMap(result, Collections.singletonMap(
+                                    "[" + (count++) + "]", object), key);
+                        }
+                    }
+                } else {
+                    result.put(key, (value != null ? value : ""));
+                }
+            }
+        }
+    }
+
+}

--- a/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/convert/converter/NacosPropertySourceConverter.java
+++ b/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/convert/converter/NacosPropertySourceConverter.java
@@ -15,8 +15,10 @@ import java.util.Properties;
 public interface NacosPropertySourceConverter {
 
     /**
-     * {yaml | json | plainText} --> properties-based string.
-     * examples:<br/>
+     * <pre>
+     * (yaml or json or plainText)-based string to properties-based string.
+     * </pre>
+     * examples:<br>
      * Input (yml-based string):
      * <pre>
      * a:
@@ -43,7 +45,7 @@ public interface NacosPropertySourceConverter {
 
     /**
      * A built-in Converter from yaml-based string to properties-based string.
-     * Main logic was copied from {@link org.springframework.beans.factory.config.YamlProcessor#buildFlattenedMap(java.util.Map, java.util.Map, java.lang.String)}
+     * Main logic was copied from org.springframework.beans.factory.config.YamlProcessor#buildFlattenedMap(java.util.Map, java.util.Map, java.lang.String)
      * <p>
      * Github Address : https://github.com/spring-projects/spring-framework/blob/5.1.x/spring-beans/src/main/java/org/springframework/beans/factory/config/YamlProcessor.java
      *

--- a/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/core/env/AbstractNacosPropertySourceBuilder.java
+++ b/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/core/env/AbstractNacosPropertySourceBuilder.java
@@ -18,8 +18,8 @@ package com.alibaba.nacos.spring.core.env;
 
 import com.alibaba.nacos.spring.context.event.DeferredApplicationEventPublisher;
 import com.alibaba.nacos.spring.context.event.config.NacosConfigMetadataEvent;
-import com.alibaba.nacos.spring.util.config.NacosConfigLoader;
 import com.alibaba.nacos.spring.convert.converter.NacosPropertySourceConverter;
+import com.alibaba.nacos.spring.util.config.NacosConfigLoader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeanInstantiationException;
@@ -41,7 +41,8 @@ import java.util.*;
 import static com.alibaba.nacos.spring.context.annotation.config.NacosPropertySource.*;
 import static com.alibaba.nacos.spring.util.GlobalNacosPropertiesSource.CONFIG;
 import static com.alibaba.nacos.spring.util.NacosBeanUtils.getNacosServiceFactoryBean;
-import static com.alibaba.nacos.spring.util.NacosUtils.*;
+import static com.alibaba.nacos.spring.util.NacosUtils.buildDefaultPropertySourceName;
+import static com.alibaba.nacos.spring.util.NacosUtils.resolveProperties;
 import static com.alibaba.spring.util.ClassUtils.resolveGenericType;
 import static java.lang.String.format;
 import static java.lang.String.valueOf;
@@ -167,8 +168,7 @@ public abstract class AbstractNacosPropertySourceBuilder<T extends BeanDefinitio
 
         final NacosPropertySourceConverter converter;
         try {
-            @SuppressWarnings("unchecked")
-            final Class<NacosPropertySourceConverter> converterClass = (Class<NacosPropertySourceConverter>) runtimeAttributes.get(CONVERTER_ATTRIBUTE_NAME);
+            @SuppressWarnings("unchecked") final Class<NacosPropertySourceConverter> converterClass = (Class<NacosPropertySourceConverter>) runtimeAttributes.get(CONVERTER_ATTRIBUTE_NAME);
             converter = BeanUtils.instantiate(converterClass);
         } catch (BeanInstantiationException e) {
             throw new RuntimeException("An exception occurred while creating the NacosPropertySourceConverter", e);

--- a/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/core/env/NacosPropertySource.java
+++ b/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/core/env/NacosPropertySource.java
@@ -16,6 +16,7 @@
  */
 package com.alibaba.nacos.spring.core.env;
 
+import com.alibaba.nacos.spring.convert.converter.NacosPropertySourceConverter;
 import org.springframework.core.env.PropertiesPropertySource;
 import org.springframework.core.env.PropertySource;
 
@@ -55,6 +56,12 @@ public class NacosPropertySource extends PropertiesPropertySource {
     private String beanName;
 
     private Class<?> beanType;
+
+    /**
+     * provided for {@link com.alibaba.nacos.spring.context.event.config.NacosConfigReceivedEvent}
+     * to convert original format to customized format
+     */
+    private NacosPropertySourceConverter nacosPropertySourceConverter;
 
     /**
      * @param name        the name of Nacos {@link PropertySource}
@@ -168,6 +175,14 @@ public class NacosPropertySource extends PropertiesPropertySource {
         this.beanType = beanType;
     }
 
+    public void setNacosPropertySourceConverter(NacosPropertySourceConverter nacosPropertySourceConverter) {
+        this.nacosPropertySourceConverter = nacosPropertySourceConverter;
+    }
+
+    public NacosPropertySourceConverter getNacosPropertySourceConverter() {
+        return nacosPropertySourceConverter;
+    }
+
     protected void copy(NacosPropertySource original) {
         this.groupId = original.groupId;
         this.dataId = original.dataId;
@@ -180,5 +195,6 @@ public class NacosPropertySource extends PropertiesPropertySource {
         this.origin = original.origin;
         this.beanName = original.beanName;
         this.beanType = original.beanType;
+        this.nacosPropertySourceConverter = original.nacosPropertySourceConverter;
     }
 }

--- a/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/core/env/XmlNacosPropertySourceBuilder.java
+++ b/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/core/env/XmlNacosPropertySourceBuilder.java
@@ -18,9 +18,11 @@ package com.alibaba.nacos.spring.core.env;
 
 import com.alibaba.nacos.spring.context.config.xml.NacosPropertySourceXmlBeanDefinition;
 import com.alibaba.nacos.spring.context.event.config.NacosConfigMetadataEvent;
+import com.alibaba.nacos.spring.convert.converter.NacosPropertySourceConverter;
 import org.springframework.beans.factory.xml.XmlReaderContext;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.core.io.Resource;
+import org.springframework.util.ClassUtils;
 import org.springframework.util.StringUtils;
 import org.w3c.dom.Element;
 import org.w3c.dom.NamedNodeMap;
@@ -56,6 +58,16 @@ public class XmlNacosPropertySourceBuilder extends
         // Nacos Metadata
         runtimeAttributes.put(DATA_ID_ATTRIBUTE_NAME, getAttribute(element, "data-id", DEFAULT_STRING_ATTRIBUTE_VALUE));
         runtimeAttributes.put(GROUP_ID_ATTRIBUTE_NAME, getAttribute(element, "group-id", DEFAULT_GROUP));
+
+        String className = getAttribute(element, "converter-class", "com.alibaba.nacos.spring.convert.converter.NacosPropertySourceConverter.SimplePropertiesConverter");
+        Class<?> converterClass;
+        try {
+            converterClass = ClassUtils.resolveClassName(className, this.getClass().getClassLoader());
+        } catch (Exception e) {
+            throw new IllegalArgumentException("an error occurred while resolve NacosPropertySourceConverter");
+        }
+        runtimeAttributes.put(CONVERTER_ATTRIBUTE_NAME, converterClass);
+
         // PropertySource Name
         runtimeAttributes.put(NAME_ATTRIBUTE_NAME, getAttribute(element, NAME_ATTRIBUTE_NAME, DEFAULT_STRING_ATTRIBUTE_VALUE));
         // TODO support nested properties

--- a/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/listener/AbstractConvertibleNacosPropertiesListener.java
+++ b/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/listener/AbstractConvertibleNacosPropertiesListener.java
@@ -1,0 +1,32 @@
+package com.alibaba.nacos.spring.listener;
+
+import com.alibaba.nacos.api.config.listener.AbstractListener;
+import com.alibaba.nacos.spring.convert.converter.NacosPropertySourceConverter;
+
+/**
+ * @author hylexus
+ * Created At 2019-06-13 11:01
+ */
+public abstract class AbstractConvertibleNacosPropertiesListener extends AbstractListener {
+    private NacosPropertySourceConverter converter;
+
+    public AbstractConvertibleNacosPropertiesListener(NacosPropertySourceConverter converter) {
+        this.converter = converter;
+    }
+
+    @Override
+    public void receiveConfigInfo(String configInfo) {
+        String properties = this.converter.convert(configInfo);
+        process(properties);
+    }
+
+    protected abstract void process(String converted);
+
+    public void setConverter(NacosPropertySourceConverter converter) {
+        this.converter = converter;
+    }
+
+    public NacosPropertySourceConverter getConverter() {
+        return converter;
+    }
+}

--- a/nacos-spring-context/src/main/resources/META-INF/schemas/nacos.xsd
+++ b/nacos-spring-context/src/main/resources/META-INF/schemas/nacos.xsd
@@ -62,6 +62,13 @@
             <xsd:attribute name="first" default="false"/>
             <xsd:attribute name="before" default=""/>
             <xsd:attribute name="after" default=""/>
+            <xsd:attribute name="converter-class" type="xsd:string">
+                <xsd:annotation>
+                    <xsd:documentation source="java:java.lang.Class"><![CDATA[
+	The fully qualified name of the Converter's class
+				]]></xsd:documentation>
+                </xsd:annotation>
+            </xsd:attribute>
         </xsd:complexType>
     </xsd:element>
 

--- a/nacos-spring-context/src/test/java/com/alibaba/nacos/spring/context/config/xml/NacosPropertySourceBeanDefinitionParserTest.java
+++ b/nacos-spring-context/src/test/java/com/alibaba/nacos/spring/context/config/xml/NacosPropertySourceBeanDefinitionParserTest.java
@@ -46,12 +46,12 @@ import static com.alibaba.nacos.embedded.web.server.NacosConfigHttpHandler.*;
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = {
-    "classpath:/META-INF/nacos-context.xml",
-    "classpath:/META-INF/nacos-property-source.xml"
+        "classpath:/META-INF/nacos-context.xml",
+        "classpath:/META-INF/nacos-property-source.xml"
 })
 @DirtiesContext
 @TestExecutionListeners({DependencyInjectionTestExecutionListener.class,
-    DirtiesContextTestExecutionListener.class, NacosPropertySourceBeanDefinitionParserTest.class})
+        DirtiesContextTestExecutionListener.class, NacosPropertySourceBeanDefinitionParserTest.class})
 public class NacosPropertySourceBeanDefinitionParserTest extends AbstractNacosHttpServerTestExecutionListener {
 
     private static final Long USER_ID = 1991L;

--- a/nacos-spring-context/src/test/resources/META-INF/nacos-property-source.xml
+++ b/nacos-spring-context/src/test/resources/META-INF/nacos-property-source.xml
@@ -8,7 +8,7 @@
         http://nacos.io/schema/nacos
         http://nacos.io/schema/nacos.xsd">
 
-    <nacos:property-source data-id="user" auto-refreshed="true" />
+    <nacos:property-source data-id="user" auto-refreshed="true" converter-class="com.alibaba.nacos.spring.convert.converter.NacosPropertySourceConverter.SimplePropertiesConverter"/>
 
     <bean name="user" class="com.alibaba.nacos.spring.test.User">
         <property name="id" value="${id}"/>


### PR DESCRIPTION
# enhancement
[NacosPropertySourceConverter support in issue#33](https://github.com/nacos-group/nacos-spring-project/issues/33)
# example
- yaml-based string in NacosServer

```yaml
job:
  executor:
    app-name: demoJob
  scheduler:
    address: http://localhost:8899/schedule
```
- Load PropertySource from yaml-based string

```java
// load property source
@NacosPropertySource(name = "jobConfig", dataId = "job.yml", autoRefreshed = true, first = true, converter = NacosPropertySourceConverter.SimpleYamlConverter.class)
```
- Reference in Java

```java
@Value("${job.executor.app-name}")
private String name;

@NacosValue(value = "${job.scheduler.address}", autoRefreshed = true)
private String address;
```