### PR TITLE
[#ISSUE 33] Support for multiple configuration type file parsing

### DIFF
--- a/nacos-spring-context/pom.xml
+++ b/nacos-spring-context/pom.xml
@@ -24,6 +24,13 @@
             <version>${nacos.version}</version>
         </dependency>
 
+        <!--yaml-->
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>${snake.yaml.version}</version>
+        </dependency>
+
         <!-- Spring Framework -->
         <dependency>
             <groupId>org.springframework</groupId>

--- a/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/beans/factory/annotation/NamingMaintainServiceBeanBuilder.java
+++ b/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/beans/factory/annotation/NamingMaintainServiceBeanBuilder.java
@@ -35,7 +35,7 @@ public class NamingMaintainServiceBeanBuilder extends AbstractNacosServiceBeanBu
     public static final String BEAN_NAME = "namingMaintainServiceBeanBuilder";
 
     protected NamingMaintainServiceBeanBuilder() {
-        super(GlobalNacosPropertiesSource.DISCOVERY);
+        super(GlobalNacosPropertiesSource.MAINTAIN);
     }
 
     @Override

--- a/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/beans/factory/annotation/NamingMaintainServiceBeanBuilder.java
+++ b/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/beans/factory/annotation/NamingMaintainServiceBeanBuilder.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.nacos.spring.beans.factory.annotation;
+
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.naming.NamingMaintainService;
+import com.alibaba.nacos.spring.factory.NacosServiceFactory;
+import com.alibaba.nacos.spring.util.GlobalNacosPropertiesSource;
+
+import java.util.Properties;
+
+/**
+ * @author <a href="mailto:liaochunyhm@live.com">liaochuntao</a>
+ * @since
+ */
+public class NamingMaintainServiceBeanBuilder extends AbstractNacosServiceBeanBuilder<NamingMaintainService>  {
+
+    /**
+     * The bean name of {@link NamingMaintainServiceBeanBuilder}
+     */
+    public static final String BEAN_NAME = "namingMaintainServiceBeanBuilder";
+
+    protected NamingMaintainServiceBeanBuilder() {
+        super(GlobalNacosPropertiesSource.DISCOVERY);
+    }
+
+    @Override
+    protected NamingMaintainService createService(NacosServiceFactory nacosServiceFactory, Properties properties)
+            throws NacosException {
+        return nacosServiceFactory.createNamingMaintainService(properties);
+    }
+
+}

--- a/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/context/annotation/config/EnableNacosConfig.java
+++ b/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/context/annotation/config/EnableNacosConfig.java
@@ -93,6 +93,24 @@ public @interface EnableNacosConfig {
      */
     String ENCODE_PLACEHOLDER = "${" + CONFIG_PREFIX + ENCODE + ":" + NacosProperties.ENCODE_PLACEHOLDER + "}";
 
+//    /**
+//     * The placeholder of {@link NacosProperties#CONFIG_LONG_POLL_TIMEOUT configLongPollTimeout}, the value is
+//     * <code>"${nacos.config.configLongPollTimeout:${nacos.configLongPollTimeout:}}"</code>
+//     */
+//    String CONFIG_LONG_POLL_TIMEOUT_PLACEHOLDER = "${" + CONFIG_PREFIX + CONFIG_LONG_POLL_TIMEOUT + ":" + NacosProperties.CONFIG_LONG_POLL_TIMEOUT_PLACEHOLDER + "}";
+//
+//    /**
+//     * The placeholder of {@link NacosProperties#CONFIG_RETRY_TIME configRetryTime}, the value is
+//     * <code>"${nacos.config.configRetryTime:${nacos.configRetryTime:}}"</code>
+//     */
+//    String CONFIG_RETRY_TIME_PLACEHOLDER = "${" + CONFIG_PREFIX + CONFIG_RETRY_TIME + ":" + NacosProperties.CONFIG_RETRY_TIME_PLACEHOLDER + "}";
+//
+//    /**
+//     * The placeholder of {@link NacosProperties#MAX_RETRY maxRetry}, the value is
+//     * <code>"${nacos.config.maxRetry:${nacos.maxRetry:}}"</code>
+//     */
+//    String MAX_RETRY_PLACEHOLDER = "${" + CONFIG_PREFIX + MAX_RETRY + ":" + NacosProperties.MAX_RETRY_PLACEHOLDER + "}";
+
     /**
      * Global {@link NacosProperties Nacos Properties}
      *

--- a/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/context/annotation/config/NacosPropertySource.java
+++ b/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/context/annotation/config/NacosPropertySource.java
@@ -27,6 +27,7 @@ import java.util.Map;
 
 import static com.alibaba.nacos.api.common.Constants.DEFAULT_GROUP;
 import static com.alibaba.nacos.spring.util.NacosUtils.DEFAULT_BOOLEAN_ATTRIBUTE_VALUE;
+import static com.alibaba.nacos.spring.util.NacosUtils.DEFAULT_CONFIG_TYPE_VALUE;
 import static com.alibaba.nacos.spring.util.NacosUtils.DEFAULT_STRING_ATTRIBUTE_VALUE;
 
 /**
@@ -82,6 +83,11 @@ public @interface NacosPropertySource {
      * The attribute name of {@link NacosPropertySource#properties()}
      */
     String PROPERTIES_ATTRIBUTE_NAME = "properties";
+
+    /**
+     * The attribute name of {@link NacosPropertySource#type()} ()}
+     */
+    String CONFIG_TYPE_ATTRIBUTE_NAME = "type";
 
     /**
      * The name of Nacos {@link PropertySource}
@@ -144,6 +150,13 @@ public @interface NacosPropertySource {
      * @return the name of {@link PropertySource}
      */
     String after() default DEFAULT_STRING_ATTRIBUTE_VALUE;
+
+    /**
+     * The type of config
+     *
+     * @return the type of config
+     */
+    String type() default DEFAULT_CONFIG_TYPE_VALUE;
 
     /**
      * The {@link NacosProperties} attribute, If not specified, it will use

--- a/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/context/annotation/config/NacosPropertySourceBuilder.java
+++ b/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/context/annotation/config/NacosPropertySourceBuilder.java
@@ -50,6 +50,8 @@ class NacosPropertySourceBuilder {
 
     private String groupId;
 
+    private String type;
+
     private Properties properties;
 
     private ConfigurableEnvironment environment;
@@ -70,6 +72,11 @@ class NacosPropertySourceBuilder {
 
     public NacosPropertySourceBuilder groupId(String groupId) {
         this.groupId = groupId;
+        return this;
+    }
+
+    public NacosPropertySourceBuilder type(String type) {
+        this.type = type;
         return this;
     }
 
@@ -113,7 +120,7 @@ class NacosPropertySourceBuilder {
             return null;
         }
 
-        Properties properties = toProperties(config);
+        Properties properties = toProperties(dataId, groupId, config, type);
 
         if (!StringUtils.hasText(name)) {
             name = buildDefaultPropertySourceName(dataId, groupId, properties);

--- a/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/context/event/DeferredApplicationEventPublisher.java
+++ b/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/context/event/DeferredApplicationEventPublisher.java
@@ -23,6 +23,7 @@ import org.springframework.context.support.AbstractApplicationContext;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 /**
  * Deferred {@link ApplicationEventPublisher} to resolve {@link #publishEvent(ApplicationEvent)} too early to publish
@@ -38,7 +39,8 @@ public class DeferredApplicationEventPublisher implements ApplicationEventPublis
 
     private final ConfigurableApplicationContext context;
 
-    private final List<ApplicationEvent> deferredEvents = new LinkedList<ApplicationEvent>();
+    // fix issue 85
+    private final ConcurrentLinkedQueue<ApplicationEvent> deferredEvents = new ConcurrentLinkedQueue<ApplicationEvent>();
 
     public DeferredApplicationEventPublisher(ConfigurableApplicationContext context) {
         this.context = context;
@@ -48,9 +50,14 @@ public class DeferredApplicationEventPublisher implements ApplicationEventPublis
     @Override
     public void publishEvent(ApplicationEvent event) {
 
-        if (context.isRunning()) {
-            context.publishEvent(event);
-        } else {
+        // fix issue 89
+        try {
+            if (context.isRunning()) {
+                context.publishEvent(event);
+            } else {
+                deferredEvents.add(event);
+            }
+        } catch (Exception ignore) {
             deferredEvents.add(event);
         }
 

--- a/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/context/properties/config/NacosConfigurationPropertiesBindingPostProcessor.java
+++ b/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/context/properties/config/NacosConfigurationPropertiesBindingPostProcessor.java
@@ -45,14 +45,6 @@ public class NacosConfigurationPropertiesBindingPostProcessor implements BeanPos
      */
     public static final String BEAN_NAME = "nacosConfigurationPropertiesBindingPostProcessor";
 
-    private Properties globalNacosProperties;
-
-    private NacosServiceFactory nacosServiceFactory;
-
-    private Environment environment;
-
-    private ApplicationEventPublisher applicationEventPublisher;
-
     private ConfigurableApplicationContext applicationContext;
 
     @Override
@@ -69,7 +61,17 @@ public class NacosConfigurationPropertiesBindingPostProcessor implements BeanPos
 
     private void bind(Object bean, String beanName, NacosConfigurationProperties nacosConfigurationProperties) {
 
-        NacosConfigurationPropertiesBinder binder = new NacosConfigurationPropertiesBinder(applicationContext);
+        NacosConfigurationPropertiesBinder binder;
+        try {
+            binder = applicationContext
+                    .getBean(NacosConfigurationPropertiesBinder.BEAN_NAME, NacosConfigurationPropertiesBinder.class);
+            if (binder == null) {
+                binder = new NacosConfigurationPropertiesBinder(applicationContext);
+            }
+
+        } catch (Exception e) {
+            binder = new NacosConfigurationPropertiesBinder(applicationContext);
+        }
 
         binder.bind(bean, beanName, nacosConfigurationProperties);
 

--- a/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/core/env/AbstractNacosPropertySourceBuilder.java
+++ b/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/core/env/AbstractNacosPropertySourceBuilder.java
@@ -144,6 +144,8 @@ public abstract class AbstractNacosPropertySourceBuilder<T extends BeanDefinitio
         String name = (String) runtimeAttributes.get(NAME_ATTRIBUTE_NAME);
         String dataId = (String) runtimeAttributes.get(DATA_ID_ATTRIBUTE_NAME);
         String groupId = (String) runtimeAttributes.get(GROUP_ID_ATTRIBUTE_NAME);
+        String type = (String) runtimeAttributes.get(CONFIG_TYPE_ATTRIBUTE_NAME);
+        type = StringUtils.isEmpty(type) ? "properties" : type;
         Map<String, Object> nacosPropertiesAttributes = (Map<String, Object>) runtimeAttributes.get(PROPERTIES_ATTRIBUTE_NAME);
 
         Properties nacosProperties = resolveProperties(nacosPropertiesAttributes, environment, globalNacosProperties);
@@ -163,7 +165,7 @@ public abstract class AbstractNacosPropertySourceBuilder<T extends BeanDefinitio
             name = buildDefaultPropertySourceName(dataId, groupId, nacosProperties);
         }
 
-        NacosPropertySource nacosPropertySource = new NacosPropertySource(name, nacosConfig);
+        NacosPropertySource nacosPropertySource = new NacosPropertySource(dataId, groupId, name, nacosConfig, type);
 
         nacosPropertySource.setBeanName(beanName);
 
@@ -173,6 +175,7 @@ public abstract class AbstractNacosPropertySourceBuilder<T extends BeanDefinitio
         }
         nacosPropertySource.setGroupId(groupId);
         nacosPropertySource.setDataId(dataId);
+        nacosPropertySource.setType(type);
         nacosPropertySource.setProperties(nacosProperties);
 
         initNacosPropertySource(nacosPropertySource, beanDefinition, runtimeAttributes);

--- a/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/core/env/NacosPropertySource.java
+++ b/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/core/env/NacosPropertySource.java
@@ -46,6 +46,8 @@ public class NacosPropertySource extends PropertiesPropertySource {
 
     private String after;
 
+    private String type = "properties";
+
     private Properties properties;
 
     private Map<String, Object> attributesMetadata;
@@ -60,8 +62,8 @@ public class NacosPropertySource extends PropertiesPropertySource {
      * @param name        the name of Nacos {@link PropertySource}
      * @param nacosConfig the Nacos Config with {@link Properties} format
      */
-    public NacosPropertySource(String name, String nacosConfig) {
-        super(name, toProperties(nacosConfig));
+    public NacosPropertySource(String dataId, String groupId, String name, String nacosConfig, String type) {
+        super(name, toProperties(dataId, groupId, nacosConfig, type));
     }
 
     public String getGroupId() {
@@ -110,6 +112,14 @@ public class NacosPropertySource extends PropertiesPropertySource {
 
     public void setAfter(String after) {
         this.after = after;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
     }
 
     public Properties getProperties() {
@@ -175,6 +185,7 @@ public class NacosPropertySource extends PropertiesPropertySource {
         this.first = original.first;
         this.before = original.before;
         this.after = original.after;
+        this.type = original.type;
         this.properties = original.properties;
         this.attributesMetadata = original.attributesMetadata;
         this.origin = original.origin;

--- a/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/core/env/NacosPropertySourcePostProcessor.java
+++ b/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/core/env/NacosPropertySourcePostProcessor.java
@@ -181,6 +181,7 @@ public class NacosPropertySourcePostProcessor implements BeanDefinitionRegistryP
 
         final String dataId = nacosPropertySource.getDataId();
         final String groupId = nacosPropertySource.getGroupId();
+        final String type = nacosPropertySource.getType();
         final NacosServiceFactory nacosServiceFactory = getNacosServiceFactoryBean(beanFactory);
 
         try {
@@ -192,7 +193,7 @@ public class NacosPropertySourcePostProcessor implements BeanDefinitionRegistryP
                 @Override
                 public void receiveConfigInfo(String config) {
                     String name = nacosPropertySource.getName();
-                    NacosPropertySource newNacosPropertySource = new NacosPropertySource(name, config);
+                    NacosPropertySource newNacosPropertySource = new NacosPropertySource(dataId, groupId, name, config, type);
                     newNacosPropertySource.copy(nacosPropertySource);
                     MutablePropertySources propertySources = environment.getPropertySources();
                     // replace NacosPropertySource

--- a/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/core/env/NacosPropertySourcePostProcessor.java
+++ b/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/core/env/NacosPropertySourcePostProcessor.java
@@ -23,8 +23,10 @@ import com.alibaba.nacos.spring.beans.factory.annotation.ConfigServiceBeanBuilde
 import com.alibaba.nacos.spring.context.annotation.config.NacosPropertySources;
 import com.alibaba.nacos.spring.context.config.xml.NacosPropertySourceXmlBeanDefinition;
 
+import com.alibaba.nacos.spring.factory.NacosServiceFactory;
 import com.alibaba.spring.util.BeanUtils;
 import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
@@ -45,9 +47,11 @@ import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 
 import static com.alibaba.nacos.spring.util.NacosBeanUtils.getConfigServiceBeanBuilder;
+import static com.alibaba.nacos.spring.util.NacosBeanUtils.getNacosServiceFactoryBean;
 import static com.alibaba.nacos.spring.util.NacosUtils.DEFAULT_STRING_ATTRIBUTE_VALUE;
 import static org.springframework.util.ObjectUtils.nullSafeEquals;
 
@@ -74,6 +78,8 @@ public class NacosPropertySourcePostProcessor implements BeanDefinitionRegistryP
      */
     public static final String BEAN_NAME = "nacosPropertySourcePostProcessor";
 
+    private static BeanFactory beanFactory;
+
     private final Set<String> processedBeanNames = new LinkedHashSet<String>();
 
     private ConfigurableEnvironment environment;
@@ -99,6 +105,7 @@ public class NacosPropertySourcePostProcessor implements BeanDefinitionRegistryP
                 beanFactory.getBean(beanName, AbstractNacosPropertySourceBuilder.class));
         }
 
+        NacosPropertySourcePostProcessor.beanFactory = beanFactory;
         this.configServiceBeanBuilder = getConfigServiceBeanBuilder(beanFactory);
 
         String[] beanNames = beanFactory.getBeanDefinitionNames();
@@ -123,7 +130,8 @@ public class NacosPropertySourcePostProcessor implements BeanDefinitionRegistryP
         // Add Orderly
         for (NacosPropertySource nacosPropertySource : nacosPropertySources) {
             addNacosPropertySource(nacosPropertySource);
-            addListenerIfAutoRefreshed(nacosPropertySource);
+            Properties properties = configServiceBeanBuilder.resolveProperties(nacosPropertySource.getAttributesMetadata());
+            addListenerIfAutoRefreshed(nacosPropertySource, properties, environment);
         }
 
         processedBeanNames.add(beanName);
@@ -165,7 +173,7 @@ public class NacosPropertySourcePostProcessor implements BeanDefinitionRegistryP
         }
     }
 
-    private void addListenerIfAutoRefreshed(final NacosPropertySource nacosPropertySource) {
+    public static void addListenerIfAutoRefreshed(final NacosPropertySource nacosPropertySource, final Properties properties, final ConfigurableEnvironment environment) {
 
         if (!nacosPropertySource.isAutoRefreshed()) { // Disable Auto-Refreshed
             return;
@@ -173,10 +181,12 @@ public class NacosPropertySourcePostProcessor implements BeanDefinitionRegistryP
 
         final String dataId = nacosPropertySource.getDataId();
         final String groupId = nacosPropertySource.getGroupId();
-        final Map<String, Object> nacosPropertiesAttributes = nacosPropertySource.getAttributesMetadata();
-        final ConfigService configService = configServiceBeanBuilder.build(nacosPropertiesAttributes);
+        final NacosServiceFactory nacosServiceFactory = getNacosServiceFactoryBean(beanFactory);
 
         try {
+
+            final ConfigService configService = nacosServiceFactory.createConfigService(properties);
+
             configService.addListener(dataId, groupId, new AbstractListener() {
 
                 @Override
@@ -190,7 +200,7 @@ public class NacosPropertySourcePostProcessor implements BeanDefinitionRegistryP
                 }
             });
         } catch (NacosException e) {
-            throw new RuntimeException("ConfigService can't add Listener with properties : " + nacosPropertiesAttributes, e);
+            throw new RuntimeException("ConfigService can't add Listener with properties : " + properties, e);
         }
     }
 

--- a/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/factory/ApplicationContextHolder.java
+++ b/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/factory/ApplicationContextHolder.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.nacos.spring.factory;
+
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+
+/**
+ * @author <a href="mailto:liaochunyhm@live.com">liaochuntao</a>
+ * @since
+ */
+public class ApplicationContextHolder implements ApplicationContextAware {
+
+    public static final String BEAN_NAME = "nacosApplicationContextHolder";
+
+    private ApplicationContext applicationContext;
+
+    @Override
+    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+        this.applicationContext = applicationContext;
+    }
+
+    public ApplicationContext getApplicationContext() {
+        return applicationContext;
+    }
+}

--- a/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/factory/CacheableEventPublishingNacosServiceFactory.java
+++ b/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/factory/CacheableEventPublishingNacosServiceFactory.java
@@ -42,7 +42,9 @@ import static com.alibaba.nacos.spring.util.NacosUtils.identify;
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
  * @since 0.1.0
  */
-public class CacheableEventPublishingNacosServiceFactory implements NacosServiceFactory, ApplicationContextAware {
+public class CacheableEventPublishingNacosServiceFactory implements NacosServiceFactory {
+
+    private static final CacheableEventPublishingNacosServiceFactory SINGLETON = new CacheableEventPublishingNacosServiceFactory();
 
     private final Map<String, ConfigService> configServicesCache = new LinkedHashMap<String, ConfigService>(2);
 
@@ -117,10 +119,10 @@ public class CacheableEventPublishingNacosServiceFactory implements NacosService
         return maintainService;
     }
 
-    @Override
     public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
-        this.context = (ConfigurableApplicationContext) applicationContext;
-        this.nacosConfigListenerExecutor = getNacosConfigListenerExecutorIfPresent(applicationContext);
+        getSingleton().context = (ConfigurableApplicationContext) applicationContext;
+        getSingleton().nacosConfigListenerExecutor = getSingleton().nacosConfigListenerExecutor == null ?
+                getNacosConfigListenerExecutorIfPresent(applicationContext) : getSingleton().nacosConfigListenerExecutor;
     }
 
     @Override
@@ -136,5 +138,9 @@ public class CacheableEventPublishingNacosServiceFactory implements NacosService
     @Override
     public Collection<NamingMaintainService> getNamingMaintainService() {
         return null;
+    }
+
+    public static CacheableEventPublishingNacosServiceFactory getSingleton() {
+        return SINGLETON;
     }
 }

--- a/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/factory/CacheableEventPublishingNacosServiceFactory.java
+++ b/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/factory/CacheableEventPublishingNacosServiceFactory.java
@@ -137,7 +137,7 @@ public class CacheableEventPublishingNacosServiceFactory implements NacosService
 
     @Override
     public Collection<NamingMaintainService> getNamingMaintainService() {
-        return null;
+        return maintainServicesCache.values();
     }
 
     public static CacheableEventPublishingNacosServiceFactory getSingleton() {

--- a/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/factory/CacheableEventPublishingNacosServiceFactory.java
+++ b/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/factory/CacheableEventPublishingNacosServiceFactory.java
@@ -19,6 +19,7 @@ package com.alibaba.nacos.spring.factory;
 import com.alibaba.nacos.api.NacosFactory;
 import com.alibaba.nacos.api.config.ConfigService;
 import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.naming.NamingMaintainService;
 import com.alibaba.nacos.api.naming.NamingService;
 import com.alibaba.nacos.spring.context.event.config.EventPublishingConfigService;
 import org.springframework.beans.BeansException;
@@ -46,6 +47,8 @@ public class CacheableEventPublishingNacosServiceFactory implements NacosService
     private final Map<String, ConfigService> configServicesCache = new LinkedHashMap<String, ConfigService>(2);
 
     private final Map<String, NamingService> namingServicesCache = new LinkedHashMap<String, NamingService>(2);
+
+    private final Map<String, NamingMaintainService> maintainServicesCache = new LinkedHashMap<String, NamingMaintainService>(2);
 
     private ConfigurableApplicationContext context;
 
@@ -95,6 +98,26 @@ public class CacheableEventPublishingNacosServiceFactory implements NacosService
     }
 
     @Override
+    public NamingMaintainService createNamingMaintainService(Properties properties) throws NacosException {
+        Properties copy = new Properties();
+
+        copy.putAll(properties);
+
+        String cacheKey = identify(copy);
+
+        NamingMaintainService maintainService;
+
+        maintainService = maintainServicesCache.get(cacheKey);
+
+        if (maintainService == null) {
+            maintainService = new DelegatingNamingMaintainService(NacosFactory.createMaintainService(properties), properties);
+            maintainServicesCache.put(cacheKey, maintainService);
+        }
+
+        return maintainService;
+    }
+
+    @Override
     public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
         this.context = (ConfigurableApplicationContext) applicationContext;
         this.nacosConfigListenerExecutor = getNacosConfigListenerExecutorIfPresent(applicationContext);
@@ -108,5 +131,10 @@ public class CacheableEventPublishingNacosServiceFactory implements NacosService
     @Override
     public Collection<NamingService> getNamingServices() {
         return namingServicesCache.values();
+    }
+
+    @Override
+    public Collection<NamingMaintainService> getNamingMaintainService() {
+        return null;
     }
 }

--- a/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/factory/CacheableEventPublishingNacosServiceFactory.java
+++ b/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/factory/CacheableEventPublishingNacosServiceFactory.java
@@ -65,7 +65,9 @@ public class CacheableEventPublishingNacosServiceFactory implements NacosService
 
         String cacheKey = identify(copy);
 
-        ConfigService configService = configServicesCache.get(cacheKey);
+        ConfigService configService;
+
+        configService = configServicesCache.get(cacheKey);
 
         if (configService == null) {
             configService = doCreateConfigService(copy);
@@ -77,7 +79,7 @@ public class CacheableEventPublishingNacosServiceFactory implements NacosService
 
     private ConfigService doCreateConfigService(Properties properties) throws NacosException {
         ConfigService configService = NacosFactory.createConfigService(properties);
-        return new EventPublishingConfigService(configService, properties, context, nacosConfigListenerExecutor);
+        return new EventPublishingConfigService(configService, properties, getSingleton().context, getSingleton().nacosConfigListenerExecutor);
     }
 
     @Override
@@ -89,7 +91,9 @@ public class CacheableEventPublishingNacosServiceFactory implements NacosService
 
         String cacheKey = identify(copy);
 
-        NamingService namingService = namingServicesCache.get(cacheKey);
+        NamingService namingService;
+
+        namingService = namingServicesCache.get(cacheKey);
 
         if (namingService == null) {
             namingService = new DelegatingNamingService(NacosFactory.createNamingService(copy), properties);

--- a/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/factory/DelegatingNamingMaintainService.java
+++ b/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/factory/DelegatingNamingMaintainService.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.nacos.spring.factory;
+
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.naming.NamingMaintainService;
+import com.alibaba.nacos.api.naming.pojo.Instance;
+import com.alibaba.nacos.api.naming.pojo.Service;
+import com.alibaba.nacos.api.selector.AbstractSelector;
+import com.alibaba.nacos.spring.metadata.NacosServiceMetaData;
+
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * @author <a href="mailto:liaochunyhm@live.com">liaochuntao</a>
+ * @since
+ */
+class DelegatingNamingMaintainService implements NamingMaintainService, NacosServiceMetaData {
+
+    private final NamingMaintainService delegate;
+
+    private final Properties properties;
+
+    DelegatingNamingMaintainService(NamingMaintainService delegate, Properties properties) {
+        this.delegate = delegate;
+        this.properties = properties;
+    }
+
+    @Override
+    public void updateInstance(String serviceName, Instance instance) throws NacosException {
+        delegate.updateInstance(serviceName, instance);
+    }
+
+    @Override
+    public void updateInstance(String serviceName, String groupName, Instance instance) throws NacosException {
+        delegate.updateInstance(serviceName, groupName, instance);
+    }
+
+    @Override
+    public Service queryService(String serviceName) throws NacosException {
+        return delegate.queryService(serviceName);
+    }
+
+    @Override
+    public Service queryService(String serviceName, String groupName) throws NacosException {
+        return delegate.queryService(serviceName, groupName);
+    }
+
+    @Override
+    public void createService(String serviceName) throws NacosException {
+        delegate.createService(serviceName);
+    }
+
+    @Override
+    public void createService(String serviceName, String groupName) throws NacosException {
+        delegate.createService(serviceName, groupName);
+    }
+
+    @Override
+    public void createService(String serviceName, String groupName, float protectThreshold) throws NacosException {
+        delegate.createService(serviceName, groupName, protectThreshold);
+    }
+
+    @Override
+    public void createService(String serviceName, String groupName, float protectThreshold, String expression) throws NacosException {
+        delegate.createService(serviceName, groupName, protectThreshold, expression);
+    }
+
+    @Override
+    public void createService(Service service, AbstractSelector selector) throws NacosException {
+        delegate.createService(service, selector);
+    }
+
+    @Override
+    public boolean deleteService(String serviceName) throws NacosException {
+        return delegate.deleteService(serviceName);
+    }
+
+    @Override
+    public boolean deleteService(String serviceName, String groupName) throws NacosException {
+        return delegate.deleteService(serviceName, groupName);
+    }
+
+    @Override
+    public void updateService(String serviceName, String groupName, float protectThreshold) throws NacosException {
+        delegate.updateService(serviceName, groupName, protectThreshold);
+    }
+
+    @Override
+    public void updateService(String serviceName, String groupName, float protectThreshold, Map<String, String> metadata) throws NacosException {
+        delegate.updateService(serviceName, groupName, protectThreshold, metadata);
+    }
+
+    @Override
+    public void updateService(Service service, AbstractSelector selector) throws NacosException {
+        delegate.updateService(service, selector);
+    }
+
+    @Override
+    public Properties getProperties() {
+        return properties;
+    }
+
+
+}

--- a/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/factory/DelegatingNamingService.java
+++ b/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/factory/DelegatingNamingService.java
@@ -21,10 +21,13 @@ import com.alibaba.nacos.api.naming.NamingService;
 import com.alibaba.nacos.api.naming.listener.EventListener;
 import com.alibaba.nacos.api.naming.pojo.Instance;
 import com.alibaba.nacos.api.naming.pojo.ListView;
+import com.alibaba.nacos.api.naming.pojo.Service;
 import com.alibaba.nacos.api.naming.pojo.ServiceInfo;
+import com.alibaba.nacos.api.selector.AbstractSelector;
 import com.alibaba.nacos.spring.metadata.NacosServiceMetaData;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 
 /**
@@ -52,12 +55,27 @@ class DelegatingNamingService implements NamingService, NacosServiceMetaData {
     }
 
     @Override
+    public void registerInstance(String serviceName, String groupName, String ip, int port) throws NacosException {
+        delegate.registerInstance(serviceName, groupName, ip, port);
+    }
+
+    @Override
     public void registerInstance(String serviceName, String ip, int port, String clusterName) throws NacosException {
         delegate.registerInstance(serviceName, ip, port, clusterName);
     }
 
     @Override
+    public void registerInstance(String serviceName, String groupName, String ip, int port, String clusterName) throws NacosException {
+        delegate.registerInstance(serviceName, groupName, ip, port, clusterName);
+    }
+
+    @Override
     public void registerInstance(String serviceName, Instance instance) throws NacosException {
+        delegate.registerInstance(serviceName, instance);
+    }
+
+    @Override
+    public void registerInstance(String serviceName, String groupName, Instance instance) throws NacosException {
         delegate.registerInstance(serviceName, instance);
     }
 
@@ -67,8 +85,23 @@ class DelegatingNamingService implements NamingService, NacosServiceMetaData {
     }
 
     @Override
+    public void deregisterInstance(String serviceName, String groupName, String ip, int port) throws NacosException {
+        delegate.deregisterInstance(serviceName, groupName, ip, port);
+    }
+
+    @Override
     public void deregisterInstance(String serviceName, String ip, int port, String clusterName) throws NacosException {
         delegate.deregisterInstance(serviceName, ip, port, clusterName);
+    }
+
+    @Override
+    public void deregisterInstance(String serviceName, String groupName, String ip, int port, String clusterName) throws NacosException {
+        delegate.deregisterInstance(serviceName, groupName, ip, port, clusterName);
+    }
+
+    @Override
+    public void deregisterInstance(String serviceName, String groupName, Instance instance) throws NacosException {
+        delegate.deregisterInstance(serviceName, groupName, instance);
     }
 
     @Override
@@ -77,8 +110,38 @@ class DelegatingNamingService implements NamingService, NacosServiceMetaData {
     }
 
     @Override
+    public List<Instance> getAllInstances(String serviceName, String groupName) throws NacosException {
+        return delegate.getAllInstances(serviceName, groupName);
+    }
+
+    @Override
+    public List<Instance> getAllInstances(String serviceName, boolean subscribe) throws NacosException {
+        return delegate.getAllInstances(serviceName, subscribe);
+    }
+
+    @Override
+    public List<Instance> getAllInstances(String serviceName, String groupName, boolean subscribe) throws NacosException {
+        return delegate.getAllInstances(serviceName, groupName, subscribe);
+    }
+
+    @Override
     public List<Instance> getAllInstances(String serviceName, List<String> clusters) throws NacosException {
         return delegate.getAllInstances(serviceName, clusters);
+    }
+
+    @Override
+    public List<Instance> getAllInstances(String serviceName, String groupName, List<String> clusters) throws NacosException {
+        return delegate.getAllInstances(serviceName, groupName, clusters);
+    }
+
+    @Override
+    public List<Instance> getAllInstances(String serviceName, List<String> clusters, boolean subscribe) throws NacosException {
+        return delegate.getAllInstances(serviceName, clusters, subscribe);
+    }
+
+    @Override
+    public List<Instance> getAllInstances(String serviceName, String groupName, List<String> clusters, boolean subscribe) throws NacosException {
+        return delegate.getAllInstances(serviceName, groupName, clusters, subscribe);
     }
 
     @Override
@@ -87,8 +150,38 @@ class DelegatingNamingService implements NamingService, NacosServiceMetaData {
     }
 
     @Override
+    public List<Instance> selectInstances(String serviceName, String groupName, boolean healthy) throws NacosException {
+        return delegate.selectInstances(serviceName, groupName, healthy);
+    }
+
+    @Override
+    public List<Instance> selectInstances(String serviceName, boolean healthy, boolean subscribe) throws NacosException {
+        return delegate.selectInstances(serviceName, healthy, subscribe);
+    }
+
+    @Override
+    public List<Instance> selectInstances(String serviceName, String groupName, boolean healthy, boolean subscribe) throws NacosException {
+        return delegate.selectInstances(serviceName, groupName, healthy, subscribe);
+    }
+
+    @Override
     public List<Instance> selectInstances(String serviceName, List<String> clusters, boolean healthy) throws NacosException {
         return delegate.selectInstances(serviceName, clusters, healthy);
+    }
+
+    @Override
+    public List<Instance> selectInstances(String serviceName, String groupName, List<String> clusters, boolean healthy) throws NacosException {
+        return delegate.selectInstances(serviceName, groupName, clusters, healthy);
+    }
+
+    @Override
+    public List<Instance> selectInstances(String serviceName, List<String> clusters, boolean healthy, boolean subscribe) throws NacosException {
+        return delegate.selectInstances(serviceName, clusters, healthy, subscribe);
+    }
+
+    @Override
+    public List<Instance> selectInstances(String serviceName, String groupName, List<String> clusters, boolean healthy, boolean subscribe) throws NacosException {
+        return delegate.selectInstances(serviceName, groupName, clusters, healthy, subscribe);
     }
 
     @Override
@@ -97,8 +190,38 @@ class DelegatingNamingService implements NamingService, NacosServiceMetaData {
     }
 
     @Override
+    public Instance selectOneHealthyInstance(String serviceName, String groupName) throws NacosException {
+        return delegate.selectOneHealthyInstance(serviceName, groupName);
+    }
+
+    @Override
+    public Instance selectOneHealthyInstance(String serviceName, boolean subscribe) throws NacosException {
+        return delegate.selectOneHealthyInstance(serviceName, subscribe);
+    }
+
+    @Override
+    public Instance selectOneHealthyInstance(String serviceName, String groupName, boolean subscribe) throws NacosException {
+        return delegate.selectOneHealthyInstance(serviceName, groupName, subscribe);
+    }
+
+    @Override
     public Instance selectOneHealthyInstance(String serviceName, List<String> clusters) throws NacosException {
         return delegate.selectOneHealthyInstance(serviceName, clusters);
+    }
+
+    @Override
+    public Instance selectOneHealthyInstance(String serviceName, String groupName, List<String> clusters) throws NacosException {
+        return delegate.selectOneHealthyInstance(serviceName, groupName, clusters);
+    }
+
+    @Override
+    public Instance selectOneHealthyInstance(String serviceName, List<String> clusters, boolean subscribe) throws NacosException {
+        return delegate.selectOneHealthyInstance(serviceName, clusters, subscribe);
+    }
+
+    @Override
+    public Instance selectOneHealthyInstance(String serviceName, String groupName, List<String> clusters, boolean subscribe) throws NacosException {
+        return delegate.selectOneHealthyInstance(serviceName, groupName, clusters, subscribe);
     }
 
     @Override
@@ -107,8 +230,18 @@ class DelegatingNamingService implements NamingService, NacosServiceMetaData {
     }
 
     @Override
+    public void subscribe(String serviceName, String groupName, EventListener listener) throws NacosException {
+
+    }
+
+    @Override
     public void subscribe(String serviceName, List<String> clusters, EventListener listener) throws NacosException {
         delegate.subscribe(serviceName, clusters, listener);
+    }
+
+    @Override
+    public void subscribe(String serviceName, String groupName, List<String> clusters, EventListener listener) throws NacosException {
+        delegate.subscribe(serviceName, groupName, clusters, listener);
     }
 
     @Override
@@ -117,13 +250,38 @@ class DelegatingNamingService implements NamingService, NacosServiceMetaData {
     }
 
     @Override
+    public void unsubscribe(String serviceName, String groupName, EventListener listener) throws NacosException {
+        delegate.unsubscribe(serviceName, groupName, listener);
+    }
+
+    @Override
     public void unsubscribe(String serviceName, List<String> clusters, EventListener listener) throws NacosException {
         delegate.unsubscribe(serviceName, clusters, listener);
     }
 
     @Override
+    public void unsubscribe(String serviceName, String groupName, List<String> clusters, EventListener listener) throws NacosException {
+        delegate.unsubscribe(serviceName, groupName, clusters, listener);
+    }
+
+    @Override
     public ListView<String> getServicesOfServer(int pageNo, int pageSize) throws NacosException {
         return delegate.getServicesOfServer(pageNo, pageSize);
+    }
+
+    @Override
+    public ListView<String> getServicesOfServer(int pageNo, int pageSize, String groupName) throws NacosException {
+        return getServicesOfServer(pageNo, pageSize, groupName);
+    }
+
+    @Override
+    public ListView<String> getServicesOfServer(int pageNo, int pageSize, AbstractSelector selector) throws NacosException {
+        return delegate.getServicesOfServer(pageNo, pageSize, selector);
+    }
+
+    @Override
+    public ListView<String> getServicesOfServer(int pageNo, int pageSize, String groupName, AbstractSelector selector) throws NacosException {
+        return delegate.getServicesOfServer(pageNo, pageSize, groupName, selector);
     }
 
     @Override

--- a/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/factory/NacosServiceFactory.java
+++ b/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/factory/NacosServiceFactory.java
@@ -19,6 +19,7 @@ package com.alibaba.nacos.spring.factory;
 import com.alibaba.nacos.api.NacosFactory;
 import com.alibaba.nacos.api.config.ConfigService;
 import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.naming.NamingMaintainService;
 import com.alibaba.nacos.api.naming.NamingService;
 
 import java.util.Collection;
@@ -59,6 +60,16 @@ public interface NacosServiceFactory {
     NamingService createNamingService(Properties properties) throws NacosException;
 
     /**
+     * Create {@link NamingMaintainService} instance
+     *
+     * @param properties init param
+     * @return a {@link NamingMaintainService} instance
+     * @throws NacosException If creation is failed.
+     * @see NacosFactory#createMaintainService(Properties)
+     */
+    NamingMaintainService createNamingMaintainService(Properties properties) throws NacosException;
+
+    /**
      * Get all instances of {@link ConfigService}
      *
      * @return read-only {@link Collection}
@@ -71,5 +82,12 @@ public interface NacosServiceFactory {
      * @return read-only {@link Collection}
      */
     Collection<NamingService> getNamingServices();
+
+    /**
+     * Get all instances of {@link NamingMaintainService}
+     *
+     * @return read-only {@link Collection}
+     */
+    Collection<NamingMaintainService> getNamingMaintainService();
 
 }

--- a/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/util/ConfigParse.java
+++ b/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/util/ConfigParse.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.nacos.spring.util;
+
+import java.util.Properties;
+
+/**
+ * @author <a href="mailto:liaochunyhm@live.com">liaochuntao</a>
+ * @since
+ */
+public interface ConfigParse {
+
+    /**
+     * parse config context to map
+     *
+     * @param configText receive config context
+     * @return {@link Properties}
+     */
+    Properties parse(String configText);
+
+    /**
+     * get this ConfigParse process config type
+     *
+     * @return this parse process type
+     */
+    String processType();
+
+    /**
+     * get config dataId
+     *
+     * @return dataId
+     */
+    String dataId();
+
+    /**
+     * get config group
+     *
+     * @return group
+     */
+    String group();
+
+}

--- a/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/util/ConfigParseUtils.java
+++ b/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/util/ConfigParseUtils.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.nacos.spring.util;
+
+import com.alibaba.nacos.spring.util.parse.DefaultJsonConfigParse;
+import com.alibaba.nacos.spring.util.parse.DefaultPropertiesConfigParse;
+import com.alibaba.nacos.spring.util.parse.DefaultXmlConfigParse;
+import com.alibaba.nacos.spring.util.parse.DefaultYamlConfigParse;
+import org.springframework.util.StringUtils;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Properties;
+import java.util.ServiceLoader;
+
+/**
+ * @author <a href="mailto:liaochunyhm@live.com">liaochuntao</a>
+ * @since
+ */
+final class ConfigParseUtils {
+
+    private static final String LINK_CHAR = "#@#";
+    private static Map<String, ConfigParse> DEFAULT_CONFIG_PARSE_MAP = new HashMap(8);
+    private static Map<String, Map<String, ConfigParse>> CUSTOMER_CONFIG_PARSE_MAP = new HashMap(8);
+
+    static {
+
+        DefaultJsonConfigParse jsonConfigParse = new DefaultJsonConfigParse();
+        DefaultPropertiesConfigParse propertiesConfigParse = new DefaultPropertiesConfigParse();
+        DefaultYamlConfigParse yamlConfigParse = new DefaultYamlConfigParse();
+        DefaultXmlConfigParse xmlConfigParse = new DefaultXmlConfigParse();
+
+        // register nacos default ConfigParse
+        DEFAULT_CONFIG_PARSE_MAP.put(jsonConfigParse.processType(), jsonConfigParse);
+        DEFAULT_CONFIG_PARSE_MAP.put(propertiesConfigParse.processType(), propertiesConfigParse);
+        DEFAULT_CONFIG_PARSE_MAP.put(yamlConfigParse.processType(), yamlConfigParse);
+        DEFAULT_CONFIG_PARSE_MAP.put(xmlConfigParse.processType(), xmlConfigParse);
+
+        DEFAULT_CONFIG_PARSE_MAP = Collections.unmodifiableMap(DEFAULT_CONFIG_PARSE_MAP);
+
+        // register customer ConfigParse
+        ServiceLoader<ConfigParse> configParses = ServiceLoader.load(ConfigParse.class);
+        StringBuilder sb = new StringBuilder();
+        for (ConfigParse configParse : configParses) {
+            if (CUSTOMER_CONFIG_PARSE_MAP.containsKey(configParse.processType())) {
+                sb.setLength(0);
+                sb.append(configParse.dataId()).append(LINK_CHAR).append(configParse.group());
+                CUSTOMER_CONFIG_PARSE_MAP.get(configParse.processType()).put(sb.toString(), configParse);
+            }
+        }
+
+        CUSTOMER_CONFIG_PARSE_MAP = Collections.unmodifiableMap(CUSTOMER_CONFIG_PARSE_MAP);
+    }
+
+    static Properties toProperties(final String context, final String type) {
+        Properties properties = new Properties();
+        if (DEFAULT_CONFIG_PARSE_MAP.containsKey(type)) {
+            ConfigParse configParse = DEFAULT_CONFIG_PARSE_MAP.get(type);
+            properties.putAll(configParse.parse(context));
+            return properties;
+        } else {
+            throw new UnsupportedOperationException("Parsing is not yet supported for this type profile : " + type);
+        }
+    }
+
+    /**
+     * XML configuration parsing to support different schemas
+     *
+     * @param dataId config dataId
+     * @param group config group
+     * @param context config context
+     * @param type config type
+     * @return {@link Properties}
+     */
+    static Properties toProperties(final String dataId, final String group, final String context, final String type) {
+        Properties properties = new Properties();
+        if (CUSTOMER_CONFIG_PARSE_MAP.isEmpty()) {
+            return toProperties(context, type);
+        } else {
+            if (CUSTOMER_CONFIG_PARSE_MAP.containsKey(type)) {
+                StringBuilder sb = new StringBuilder();
+                sb.append(dataId).append(LINK_CHAR).append(group);
+                ConfigParse configParse = CUSTOMER_CONFIG_PARSE_MAP.get(type).get(sb.toString());
+                if (configParse == null) {
+                    throw new NoSuchElementException("This config can't find ConfigParse to parse");
+                }
+                properties.putAll(configParse.parse(context));
+                return properties;
+            } else {
+                throw new UnsupportedOperationException("Parsing is not yet supported for this type profile");
+            }
+        }
+    }
+
+}

--- a/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/util/GlobalNacosPropertiesSource.java
+++ b/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/util/GlobalNacosPropertiesSource.java
@@ -47,7 +47,12 @@ public enum GlobalNacosPropertiesSource {
     /**
      * Global {@link NacosProperties} for Nacos discovery
      */
-    DISCOVERY(DISCOVERY_GLOBAL_NACOS_PROPERTIES_BEAN_NAME);
+    DISCOVERY(DISCOVERY_GLOBAL_NACOS_PROPERTIES_BEAN_NAME),
+
+    /**
+     * Global {@link NacosProperties} for Nacos maintain
+     */
+    MAINTAIN(DISCOVERY_MAINTAIN_GLOBAL_NACOS_PROPERTIES_BEAN_NAME);
 
 
     private final String beanName;

--- a/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/util/NacosBeanUtils.java
+++ b/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/util/NacosBeanUtils.java
@@ -28,6 +28,7 @@ import com.alibaba.nacos.spring.context.properties.config.NacosConfigurationProp
 import com.alibaba.nacos.spring.core.env.AnnotationNacosPropertySourceBuilder;
 import com.alibaba.nacos.spring.core.env.NacosPropertySourcePostProcessor;
 import com.alibaba.nacos.spring.core.env.XmlNacosPropertySourceBuilder;
+import com.alibaba.nacos.spring.factory.ApplicationContextHolder;
 import com.alibaba.nacos.spring.factory.CacheableEventPublishingNacosServiceFactory;
 import com.alibaba.nacos.spring.factory.NacosServiceFactory;
 import com.alibaba.spring.util.BeanUtils;
@@ -228,6 +229,15 @@ public abstract class NacosBeanUtils {
         registerSingleton(registry, beanName, globalProperties);
     }
 
+    /**
+     * Register {@link ApplicationContextHolder ApplicationContextHolder}
+     *
+     * @param registry {@link BeanDefinitionRegistry}
+     */
+    public static void registerApplicationContextHolder(BeanDefinitionRegistry registry) {
+        registerInfrastructureBeanIfAbsent(registry, ApplicationContextHolder.BEAN_NAME,
+                ApplicationContextHolder.class);
+    }
 
     /**
      * Register {@link CacheableEventPublishingNacosServiceFactory NacosServiceFactory}
@@ -410,7 +420,21 @@ public abstract class NacosBeanUtils {
      * @throws NoSuchBeanDefinitionException if there is no such bean definition
      */
     public static NacosServiceFactory getNacosServiceFactoryBean(BeanFactory beanFactory) throws NoSuchBeanDefinitionException {
-        return beanFactory.getBean(CacheableEventPublishingNacosServiceFactory.BEAN_NAME, NacosServiceFactory.class);
+        if (null == beanFactory) {
+            return getNacosServiceFactoryBean();
+        }
+        ApplicationContextHolder applicationContextHolder = getApplicationContextHolder(beanFactory);
+        CacheableEventPublishingNacosServiceFactory nacosServiceFactory = CacheableEventPublishingNacosServiceFactory.getSingleton();
+        nacosServiceFactory.setApplicationContext(applicationContextHolder.getApplicationContext());
+        return nacosServiceFactory;
+    }
+
+    public static NacosServiceFactory getNacosServiceFactoryBean() throws NoSuchBeanDefinitionException {
+        return CacheableEventPublishingNacosServiceFactory.getSingleton();
+    }
+
+    public static ApplicationContextHolder getApplicationContextHolder(BeanFactory beanFactory) throws NoSuchBeanDefinitionException {
+        return beanFactory.getBean(ApplicationContextHolder.BEAN_NAME, ApplicationContextHolder.class);
     }
 
     /**

--- a/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/util/NacosBeanUtils.java
+++ b/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/util/NacosBeanUtils.java
@@ -16,7 +16,6 @@
  */
 package com.alibaba.nacos.spring.util;
 
-import com.alibaba.nacos.api.naming.NamingMaintainService;
 import com.alibaba.nacos.spring.beans.factory.annotation.AnnotationNacosInjectedBeanPostProcessor;
 import com.alibaba.nacos.spring.beans.factory.annotation.ConfigServiceBeanBuilder;
 import com.alibaba.nacos.spring.beans.factory.annotation.NamingMaintainServiceBeanBuilder;
@@ -239,16 +238,6 @@ public abstract class NacosBeanUtils {
                 ApplicationContextHolder.class);
     }
 
-    /**
-     * Register {@link CacheableEventPublishingNacosServiceFactory NacosServiceFactory}
-     *
-     * @param registry {@link BeanDefinitionRegistry}
-     */
-    public static void registerNacosServiceFactory(BeanDefinitionRegistry registry) {
-        registerInfrastructureBeanIfAbsent(registry, CacheableEventPublishingNacosServiceFactory.BEAN_NAME,
-                CacheableEventPublishingNacosServiceFactory.class);
-    }
-
     public static void registerNacosConfigPropertiesBindingPostProcessor(BeanDefinitionRegistry registry) {
         registerInfrastructureBeanIfAbsent(registry, NacosConfigurationPropertiesBindingPostProcessor.BEAN_NAME,
                 NacosConfigurationPropertiesBindingPostProcessor.class);
@@ -314,8 +303,8 @@ public abstract class NacosBeanUtils {
      * @param registry {@link BeanDefinitionRegistry}
      */
     public static void registerNacosCommonBeans(BeanDefinitionRegistry registry) {
-        // Register NacosServiceFactory Bean
-        registerNacosServiceFactory(registry);
+        // Register ApplicationContextHolder Bean
+        registerApplicationContextHolder(registry);
         // Register AnnotationNacosInjectedBeanPostProcessor Bean
         registerAnnotationNacosInjectedBeanPostProcessor(registry);
     }
@@ -370,8 +359,10 @@ public abstract class NacosBeanUtils {
 
     /**
      * Register Nacos Discovery Beans
+     * Register Nacos Discovery Beans of NamingService and NamingMaintainService
      *
      * @param registry {@link BeanDefinitionRegistry}
+     * @author liaochuntao
      */
     public static void registerNacosDiscoveryBeans(BeanDefinitionRegistry registry) {
         registerNamingServiceBeanBuilder(registry);
@@ -465,7 +456,7 @@ public abstract class NacosBeanUtils {
      * Get {@link NamingServiceBeanBuilder} Bean
      *
      * @param beanFactory {@link BeanFactory}
-     * @return {@link ConfigServiceBeanBuilder} Bean
+     * @return {@link NamingServiceBeanBuilder} Bean
      * @throws NoSuchBeanDefinitionException if there is no such bean definition
      */
     public static NamingServiceBeanBuilder getNamingServiceBeanBuilder(BeanFactory beanFactory) throws NoSuchBeanDefinitionException {
@@ -473,10 +464,10 @@ public abstract class NacosBeanUtils {
     }
 
     /**
-     * Get {@link NamingServiceBeanBuilder} Bean
+     * Get {@link NamingMaintainServiceBeanBuilder} Bean
      *
      * @param beanFactory {@link BeanFactory}
-     * @return {@link ConfigServiceBeanBuilder} Bean
+     * @return {@link NamingMaintainServiceBeanBuilder} Bean
      * @throws NoSuchBeanDefinitionException if there is no such bean definition
      */
     public static NamingMaintainServiceBeanBuilder getNamingMaintainServiceBeanBuilder(BeanFactory beanFactory) throws NoSuchBeanDefinitionException {

--- a/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/util/NacosBeanUtils.java
+++ b/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/util/NacosBeanUtils.java
@@ -16,8 +16,10 @@
  */
 package com.alibaba.nacos.spring.util;
 
+import com.alibaba.nacos.api.naming.NamingMaintainService;
 import com.alibaba.nacos.spring.beans.factory.annotation.AnnotationNacosInjectedBeanPostProcessor;
 import com.alibaba.nacos.spring.beans.factory.annotation.ConfigServiceBeanBuilder;
+import com.alibaba.nacos.spring.beans.factory.annotation.NamingMaintainServiceBeanBuilder;
 import com.alibaba.nacos.spring.beans.factory.annotation.NamingServiceBeanBuilder;
 import com.alibaba.nacos.spring.context.annotation.config.NacosConfigListenerMethodProcessor;
 import com.alibaba.nacos.spring.context.annotation.config.NacosValueAnnotationBeanPostProcessor;
@@ -363,6 +365,7 @@ public abstract class NacosBeanUtils {
      */
     public static void registerNacosDiscoveryBeans(BeanDefinitionRegistry registry) {
         registerNamingServiceBeanBuilder(registry);
+        registerNamingMaintainServiceBeanBuilder(registry);
     }
 
     /**
@@ -382,6 +385,10 @@ public abstract class NacosBeanUtils {
 
     private static void registerNamingServiceBeanBuilder(BeanDefinitionRegistry registry) {
         registerInfrastructureBeanIfAbsent(registry, NamingServiceBeanBuilder.BEAN_NAME, NamingServiceBeanBuilder.class);
+    }
+
+    private static void registerNamingMaintainServiceBeanBuilder(BeanDefinitionRegistry registry) {
+        registerInfrastructureBeanIfAbsent(registry, NamingMaintainServiceBeanBuilder.BEAN_NAME, NamingMaintainServiceBeanBuilder.class);
     }
 
     /**
@@ -439,6 +446,17 @@ public abstract class NacosBeanUtils {
      */
     public static NamingServiceBeanBuilder getNamingServiceBeanBuilder(BeanFactory beanFactory) throws NoSuchBeanDefinitionException {
         return beanFactory.getBean(NamingServiceBeanBuilder.BEAN_NAME, NamingServiceBeanBuilder.class);
+    }
+
+    /**
+     * Get {@link NamingServiceBeanBuilder} Bean
+     *
+     * @param beanFactory {@link BeanFactory}
+     * @return {@link ConfigServiceBeanBuilder} Bean
+     * @throws NoSuchBeanDefinitionException if there is no such bean definition
+     */
+    public static NamingMaintainServiceBeanBuilder getNamingMaintainServiceBeanBuilder(BeanFactory beanFactory) throws NoSuchBeanDefinitionException {
+        return beanFactory.getBean(NamingMaintainServiceBeanBuilder.BEAN_NAME, NamingMaintainServiceBeanBuilder.class);
     }
 
 }

--- a/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/util/NacosBeanUtils.java
+++ b/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/util/NacosBeanUtils.java
@@ -90,6 +90,12 @@ public abstract class NacosBeanUtils {
             "$discovery";
 
     /**
+     * The bean name of global Nacos {@link Properties} for discovery
+     */
+    public static final String DISCOVERY_MAINTAIN_GLOBAL_NACOS_PROPERTIES_BEAN_NAME = GLOBAL_NACOS_PROPERTIES_BEAN_NAME +
+            "$maintain";
+
+    /**
      * The bean name of {@link Executor} for Nacos Config Listener
      */
     public static final String NACOS_CONFIG_LISTENER_EXECUTOR_BEAN_NAME = "nacosConfigListenerExecutor";

--- a/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/util/NacosUtils.java
+++ b/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/util/NacosUtils.java
@@ -56,6 +56,11 @@ public abstract class NacosUtils {
      */
     public static final String DEFAULT_STRING_ATTRIBUTE_VALUE = "";
 
+    /**
+     * Default value of {@link String} attribute for {@link Annotation}
+     */
+    public static final String DEFAULT_CONFIG_TYPE_VALUE = "properties";
+
 
     /**
      * Default value of boolean attribute for {@link Annotation}
@@ -264,18 +269,28 @@ public abstract class NacosUtils {
     }
 
     public static Properties toProperties(String text) {
-        Properties properties = new Properties();
-        try {
-            if (StringUtils.hasText(text)) {
-                properties.load(new StringReader(text));
-            }
-        } catch (IOException e) {
-            if (logger.isErrorEnabled()) {
-                logger.error(e.getMessage(), e);
-            }
-        }
-        return properties;
+        return toProperties(text, "properties");
     }
 
+    public static Properties toProperties(String text, String type) {
+        return ConfigParseUtils.toProperties(text, type);
+    }
+
+    public static Properties toProperties(String dataId, String group, String text) {
+        return ConfigParseUtils.toProperties(dataId, group, text, "properties");
+    }
+
+    /**
+     * XML configuration parsing to support different schemas
+     *
+     * @param dataId config dataId
+     * @param group config group
+     * @param text config context
+     * @param type config type
+     * @return {@link Properties}
+     */
+    public static Properties toProperties(String dataId, String group, String text, String type) {
+        return ConfigParseUtils.toProperties(dataId, group, text, type);
+    }
 
 }

--- a/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/util/parse/ConfigParseException.java
+++ b/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/util/parse/ConfigParseException.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.nacos.spring.util.parse;
+
+/**
+ * @author <a href="mailto:liaochunyhm@live.com">liaochuntao</a>
+ * @since
+ */
+public class ConfigParseException extends RuntimeException {
+
+    public ConfigParseException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/util/parse/DefaultJsonConfigParse.java
+++ b/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/util/parse/DefaultJsonConfigParse.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.nacos.spring.util.parse;
+
+import com.alibaba.nacos.spring.util.ConfigParse;
+
+import java.util.Map;
+import java.util.Properties;
+
+import static com.alibaba.nacos.spring.util.parse.DefaultYamlConfigParse.createYaml;
+
+/**
+ * @author <a href="mailto:liaochunyhm@live.com">liaochuntao</a>
+ * @since
+ */
+public class DefaultJsonConfigParse implements ConfigParse {
+
+    @Override
+    public Properties parse(String configText) {
+        final Properties result = new Properties();
+        DefaultYamlConfigParse.process(new DefaultYamlConfigParse.MatchCallback() {
+            @Override
+            public void process(Properties properties, Map<String, Object> map) {
+                result.putAll(properties);
+            }
+        }, createYaml(), configText);
+        return result;
+    }
+
+    @Override
+    public String processType() {
+        return "json";
+    }
+
+    @Override
+    public String dataId() {
+        return null;
+    }
+
+    @Override
+    public String group() {
+        return null;
+    }
+}
+

--- a/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/util/parse/DefaultPropertiesConfigParse.java
+++ b/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/util/parse/DefaultPropertiesConfigParse.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.nacos.spring.util.parse;
+
+import com.alibaba.nacos.spring.util.ConfigParse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.util.StringUtils;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.Properties;
+
+/**
+ * @author <a href="mailto:liaochunyhm@live.com">liaochuntao</a>
+ * @since
+ */
+public class DefaultPropertiesConfigParse implements ConfigParse {
+
+    private static final Logger logger = LoggerFactory.getLogger(DefaultPropertiesConfigParse.class);
+
+    @Override
+    public Properties parse(String configText) {
+        Properties properties = new Properties();
+        try {
+            if (StringUtils.hasText(configText)) {
+                properties.load(new StringReader(configText));
+            }
+        } catch (IOException e) {
+            if (logger.isErrorEnabled()) {
+                logger.error(e.getMessage(), e);
+            }
+        }
+        return properties;
+    }
+
+    @Override
+    public String processType() {
+        return "properties";
+    }
+
+    @Override
+    public String dataId() {
+        return null;
+    }
+
+    @Override
+    public String group() {
+        return null;
+    }
+}
+

--- a/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/util/parse/DefaultXmlConfigParse.java
+++ b/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/util/parse/DefaultXmlConfigParse.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.nacos.spring.util.parse;
+
+import com.alibaba.nacos.spring.util.ConfigParse;
+import org.springframework.util.StringUtils;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.ByteArrayInputStream;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+/*
+<xmlSign>
+    <Students>
+        <Student>
+            <Name>lct-1</Name>
+            <Num>1006010022</Num>
+            <Classes>major-1</Classes>
+            <Address>hangzhou</Address>
+            <Tel>123456</Tel>
+        </Student>
+        <Student>
+            <Name>lct-2</Name>
+            <Num>1006010033</Num>
+            <Classes>major-2</Classes>
+            <Address>shengzheng</Address>
+            <Tel>234567</Tel>
+        </Student>
+        <Student>
+            <Name>lct-3</Name>
+            <Num>1006010044</Num>
+            <Classes>major-3</Classes>
+            <Address>wenzhou</Address>
+            <Tel>345678</Tel>
+        </Student>
+        <Student>
+            <Name>lct-4</Name>
+            <Num>1006010055</Num>
+            <Classes>major-3</Classes>
+            <Address>wuhan</Address>
+            <Tel>456789</Tel>
+        </Student>
+    </Students>
+</xmlSign>
+ */
+/**
+ * Just support xml config like this
+ * 
+ * @author <a href="mailto:liaochunyhm@live.com">liaochuntao</a>
+ * @since
+ */
+public class DefaultXmlConfigParse implements ConfigParse {
+
+    private DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+
+    @Override
+    public Properties parse(String configText) {
+        Properties properties = new Properties();
+        try {
+            Document document = factory.newDocumentBuilder().parse(new ByteArrayInputStream(configText.getBytes("UTF-8")));
+            Element root = document.getDocumentElement();
+            Map<String, Object> map = new LinkedHashMap<String, Object>(8);
+            recursionXmlToMap(map, root);
+            String xmlSign = root.getNodeName();
+            mapToProperties("", properties, map.get(xmlSign));
+        } catch (Exception e) {
+            throw new ConfigParseException(e);
+        }
+        return properties;
+    }
+
+    private void recursionXmlToMap(Map<String, Object> outMap, Element element) {
+        NodeList nodeList = element.getChildNodes();
+        String name = element.getNodeName();
+        if (nodeList.getLength() == 1 && !nodeList.item(0).hasChildNodes()) {
+            addData(outMap, name, element.getTextContent());
+        } else {
+            Map<String, Object> innerMap = new LinkedHashMap<String, Object>(1);
+            int length = nodeList.getLength();
+            for (int i = 0; i < length; i ++) {
+                Node node = nodeList.item(i);
+                if (node.getNodeType() == Node.ELEMENT_NODE) {
+                    Element tElement = (Element) node;
+                    recursionXmlToMap(innerMap, tElement);
+                }
+            }
+            addData(outMap, name, innerMap);
+        }
+    }
+
+    private void addData(Map<String, Object> map, String key, Object data) {
+        if (map.containsKey(key)) {
+            if (map.get(key) instanceof List) {
+                ((List) map.get(key)).add(data);
+            } else {
+                List<Object> list = new LinkedList<Object>();
+                list.add(map.get(key));
+                map.put(key, list);
+            }
+        } else {
+            map.put(key, data);
+        }
+    }
+
+    private void mapToProperties(String prefixName, Properties properties, Object data) {
+        if (data instanceof List) {
+            List list = (List) data;
+            for (int i = 0; i < list.size(); i ++) {
+                int lastIndex = prefixName.lastIndexOf('.');
+                String preName = prefixName.substring(0, lastIndex);
+                String lastName = prefixName.substring(lastIndex);
+                mapToProperties(preName + "[" + i + "]", properties, list.get(i));
+            }
+        } else if (data instanceof Map) {
+            Map<String, Object> map = (Map<String, Object>) data;
+            for (Map.Entry<String, Object> entry : map.entrySet()) {
+                String tmpPrefix = StringUtils.isEmpty(prefixName) ? entry.getKey() : prefixName  + "." + entry.getKey();
+                mapToProperties(tmpPrefix, properties, entry.getValue());
+            }
+        } else {
+            properties.setProperty(prefixName, String.valueOf(data));
+        }
+    }
+
+    @Override
+    public String processType() {
+        return "xml";
+    }
+
+    @Override
+    public String dataId() {
+        return null;
+    }
+
+    @Override
+    public String group() {
+        return null;
+    }
+}

--- a/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/util/parse/DefaultYamlConfigParse.java
+++ b/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/util/parse/DefaultYamlConfigParse.java
@@ -1,0 +1,212 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.nacos.spring.util.parse;
+
+import com.alibaba.nacos.spring.util.ConfigParse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.Constructor;
+import org.yaml.snakeyaml.nodes.MappingNode;
+import org.yaml.snakeyaml.parser.ParserException;
+
+import java.util.AbstractMap;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+/**
+ * @author <a href="mailto:liaochunyhm@live.com">liaochuntao</a>
+ * @since
+ */
+public class DefaultYamlConfigParse implements ConfigParse {
+
+    protected static final Logger logger = LoggerFactory.getLogger(DefaultYamlConfigParse.class);
+
+    protected static Yaml createYaml() {
+        return new Yaml(new MapAppenderConstructor());
+    }
+
+    @Override
+    public Properties parse(String configText) {
+        final Properties result = new Properties();
+        process(new MatchCallback() {
+            @Override
+            public void process(Properties properties, Map<String, Object> map) {
+                result.putAll(properties);
+            }
+        }, createYaml(), configText);
+        return result;
+    }
+
+    @Override
+    public String processType() {
+        return "yaml";
+    }
+
+    @Override
+    public String dataId() {
+        return null;
+    }
+
+    @Override
+    public String group() {
+        return null;
+    }
+
+    protected static boolean process(MatchCallback callback, Yaml yaml, String content) {
+        int count = 0;
+        if (logger.isDebugEnabled()) {
+            logger.debug("Loading from YAML: " + content);
+        }
+        for (Object object : yaml.loadAll(content)) {
+            if (object != null && process(asMap(object), callback)) {
+                count++;
+            }
+        }
+        if (logger.isDebugEnabled()) {
+            logger.debug("Loaded " + count + " document" + (count > 1 ? "s" : "") + " from YAML resource: " + content);
+        }
+        return (count > 0);
+    }
+
+    protected static boolean process(Map<String, Object> map, MatchCallback callback) {
+        Properties properties = new Properties();
+        properties.putAll(getFlattenedMap(map));
+
+        if (logger.isDebugEnabled()) {
+            logger.debug("Merging document (no matchers set): " + map);
+        }
+        callback.process(properties, map);
+        return true;
+    }
+
+    @SuppressWarnings("unchecked")
+    protected static Map<String, Object> asMap(Object object) {
+        // YAML can have numbers as keys
+        Map<String, Object> result = new LinkedHashMap();
+        if (!(object instanceof Map)) {
+            // A document can be a text literal
+            result.put("document", object);
+            return result;
+        }
+
+        Map<Object, Object> map = (Map<Object, Object>) object;
+        for (Map.Entry<Object, Object> entry : map.entrySet()) {
+            Object key = entry.getKey();
+            Object value = entry.getValue();
+            if (value instanceof Map) {
+                value = asMap(value);
+            }
+            if (key instanceof CharSequence) {
+                result.put(key.toString(), value);
+            }
+            else {
+                result.put("[" + key.toString() + "]", value);
+            }
+        }
+        return result;
+    }
+
+    protected static Map<String, Object> getFlattenedMap(Map<String, Object> source) {
+        Map<String, Object> result = new LinkedHashMap();
+        buildFlattenedMap(result, source, null);
+        return result;
+    }
+
+    protected static void buildFlattenedMap(Map<String, Object> result, Map<String, Object> source, String path) {
+        for (Map.Entry<String, Object> entry : source.entrySet()) {
+            String key = entry.getKey();
+            if (!com.alibaba.nacos.client.utils.StringUtils.isBlank(path)) {
+                if (key.startsWith("[")) {
+                    key = path + key;
+                } else {
+                    key = path + '.' + key;
+                }
+            }
+            Object value = entry.getValue();
+            if (value instanceof String) {
+                result.put(key, value);
+            } else if (value instanceof Map) {
+                // Need a compound key
+                @SuppressWarnings("unchecked")
+                Map<String, Object> map = (Map<String, Object>) value;
+                buildFlattenedMap(result, map, key);
+            } else if (value instanceof Collection) {
+                // Need a compound key
+                @SuppressWarnings("unchecked")
+                Collection<Object> collection = (Collection<Object>) value;
+                int count = 0;
+                for (Object object : collection) {
+                    buildFlattenedMap(result, Collections.singletonMap("[" + (count++) + "]", object), key);
+                }
+            } else {
+                result.put(key, (value != null ? value.toString() : ""));
+            }
+        }
+    }
+
+    protected interface MatchCallback {
+
+        /**
+         * Put Map to Properties
+         *
+         * @param properties {@link Properties}
+         * @param map {@link Map}
+         */
+        void process(Properties properties, Map<String, Object> map);
+    }
+
+    protected static class MapAppenderConstructor extends Constructor {
+
+        MapAppenderConstructor() {
+            super();
+        }
+
+        @Override
+        protected Map<Object, Object> constructMapping(MappingNode node) {
+            try {
+                return super.constructMapping(node);
+            } catch (IllegalStateException ex) {
+                throw new ParserException("while parsing MappingNode", node.getStartMark(), ex.getMessage(), node.getEndMark());
+            }
+        }
+
+        @Override
+        protected Map<Object, Object> createDefaultMap() {
+            final Map<Object, Object> delegate = super.createDefaultMap();
+            return new AbstractMap<Object, Object>() {
+                @Override
+                public Object put(Object key, Object value) {
+                    if (delegate.containsKey(key)) {
+                        throw new IllegalStateException("Duplicate key: " + key);
+                    }
+                    return delegate.put(key, value);
+                }
+
+                @Override
+                public Set<Entry<Object, Object>> entrySet() {
+                    return delegate.entrySet();
+                }
+            };
+        }
+    }
+
+}

--- a/nacos-spring-context/src/test/java/com/alibaba/nacos/spring/beans/factory/annotation/AnnotationNacosInjectedBeanPostProcessorTest.java
+++ b/nacos-spring-context/src/test/java/com/alibaba/nacos/spring/beans/factory/annotation/AnnotationNacosInjectedBeanPostProcessorTest.java
@@ -24,6 +24,7 @@ import com.alibaba.nacos.api.naming.NamingService;
 import com.alibaba.nacos.spring.context.annotation.EnableNacos;
 import com.alibaba.nacos.spring.factory.ApplicationContextHolder;
 import com.alibaba.nacos.spring.test.AbstractNacosHttpServerTestExecutionListener;
+import com.alibaba.nacos.spring.test.TestApplicationHolder;
 import com.alibaba.nacos.spring.test.TestConfiguration;
 import org.junit.Assert;
 import org.junit.Test;
@@ -46,6 +47,7 @@ import static com.alibaba.nacos.spring.test.MockNacosServiceFactory.*;
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = {
+        TestApplicationHolder.class,
         ConfigServiceBeanBuilder.class,
         NamingServiceBeanBuilder.class,
         AnnotationNacosInjectedBeanPostProcessor.class,
@@ -73,13 +75,6 @@ public class AnnotationNacosInjectedBeanPostProcessorTest extends AbstractNacosH
 
     @NacosInjected(properties = @NacosProperties(encode = "GBK"))
     private NamingService namingService3;
-
-    @Bean(name = ApplicationContextHolder.BEAN_NAME)
-    public ApplicationContextHolder applicationContextHolder(ApplicationContext applicationContext) {
-        ApplicationContextHolder applicationContextHolder = new ApplicationContextHolder();
-        applicationContextHolder.setApplicationContext(applicationContext);
-        return applicationContextHolder;
-    }
 
     @Override
     protected String getServerAddressPropertyName() {

--- a/nacos-spring-context/src/test/java/com/alibaba/nacos/spring/beans/factory/annotation/AnnotationNacosInjectedBeanPostProcessorTest.java
+++ b/nacos-spring-context/src/test/java/com/alibaba/nacos/spring/beans/factory/annotation/AnnotationNacosInjectedBeanPostProcessorTest.java
@@ -24,8 +24,6 @@ import com.alibaba.nacos.api.naming.NamingService;
 import com.alibaba.nacos.spring.context.annotation.EnableNacos;
 import com.alibaba.nacos.spring.factory.ApplicationContextHolder;
 import com.alibaba.nacos.spring.test.AbstractNacosHttpServerTestExecutionListener;
-import com.alibaba.nacos.spring.test.TestApplicationHolder;
-import com.alibaba.nacos.spring.test.TestConfiguration;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -47,7 +45,6 @@ import static com.alibaba.nacos.spring.test.MockNacosServiceFactory.*;
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = {
-        TestApplicationHolder.class,
         ConfigServiceBeanBuilder.class,
         NamingServiceBeanBuilder.class,
         AnnotationNacosInjectedBeanPostProcessor.class,
@@ -57,6 +54,13 @@ import static com.alibaba.nacos.spring.test.MockNacosServiceFactory.*;
         DirtiesContextTestExecutionListener.class, AnnotationNacosInjectedBeanPostProcessorTest.class})
 @EnableNacos(globalProperties = @NacosProperties(serverAddr = "${server.addr}"))
 public class AnnotationNacosInjectedBeanPostProcessorTest extends AbstractNacosHttpServerTestExecutionListener {
+
+    @Bean(name = ApplicationContextHolder.BEAN_NAME)
+    public ApplicationContextHolder applicationContextHolder(ApplicationContext applicationContext) {
+        ApplicationContextHolder applicationContextHolder = new ApplicationContextHolder();
+        applicationContextHolder.setApplicationContext(applicationContext);
+        return applicationContextHolder;
+    }
 
     @NacosInjected
     private ConfigService configService;
@@ -76,11 +80,6 @@ public class AnnotationNacosInjectedBeanPostProcessorTest extends AbstractNacosH
     @NacosInjected(properties = @NacosProperties(encode = "GBK"))
     private NamingService namingService3;
 
-    @Override
-    protected String getServerAddressPropertyName() {
-        return "server.addr";
-    }
-
     @Test
     public void testInjection() {
 
@@ -95,5 +94,10 @@ public class AnnotationNacosInjectedBeanPostProcessorTest extends AbstractNacosH
     public void test() throws NacosException {
         configService.publishConfig(DATA_ID, GROUP_ID, CONTENT);
         Assert.assertEquals(CONTENT, configService.getConfig(DATA_ID, GROUP_ID, 5000));
+    }
+
+    @Override
+    protected String getServerAddressPropertyName() {
+        return "server.addr";
     }
 }

--- a/nacos-spring-context/src/test/java/com/alibaba/nacos/spring/context/annotation/NacosBeanDefinitionRegistrarTest.java
+++ b/nacos-spring-context/src/test/java/com/alibaba/nacos/spring/context/annotation/NacosBeanDefinitionRegistrarTest.java
@@ -69,14 +69,14 @@ import static com.alibaba.nacos.spring.util.NacosBeanUtils.PLACEHOLDER_CONFIGURE
 })
 @TestExecutionListeners({DependencyInjectionTestExecutionListener.class,
         DirtiesContextTestExecutionListener.class, NacosBeanDefinitionRegistrarTest.class})
-@EnableNacos(globalProperties = @NacosProperties(serverAddr = "${serverAddr}"))
+@EnableNacos(globalProperties = @NacosProperties(serverAddr = "${server.addr}"))
 @EnableNacosConfig
 @EnableNacosDiscovery
 public class NacosBeanDefinitionRegistrarTest extends AbstractNacosHttpServerTestExecutionListener {
 
     @Override
     protected String getServerAddressPropertyName() {
-        return "serverAddr";
+        return "server.addr";
     }
 
     @Bean
@@ -94,10 +94,6 @@ public class NacosBeanDefinitionRegistrarTest extends AbstractNacosHttpServerTes
     @Autowired
     @Qualifier(NacosBeanUtils.DISCOVERY_GLOBAL_NACOS_PROPERTIES_BEAN_NAME)
     private Properties discoveryGlobalProperties;
-
-    @Autowired
-    @Qualifier(CacheableEventPublishingNacosServiceFactory.BEAN_NAME)
-    private NacosServiceFactory nacosServiceFactory;
 
     @Autowired
     @Qualifier(AnnotationNacosInjectedBeanPostProcessor.BEAN_NAME)
@@ -142,7 +138,7 @@ public class NacosBeanDefinitionRegistrarTest extends AbstractNacosHttpServerTes
     @NacosInjected
     private ConfigService globalConfigService;
 
-    @NacosInjected(properties = @NacosProperties(serverAddr = "${serverAddr}"))
+    @NacosInjected(properties = @NacosProperties(serverAddr = "${server.addr}"))
     private ConfigService configService;
 
     @NacosInjected

--- a/nacos-spring-context/src/test/java/com/alibaba/nacos/spring/context/annotation/config/NacosConfigListenerMethodProcessorTest.java
+++ b/nacos-spring-context/src/test/java/com/alibaba/nacos/spring/context/annotation/config/NacosConfigListenerMethodProcessorTest.java
@@ -69,9 +69,6 @@ import static org.junit.Assert.assertNull;
 @EnableNacos(globalProperties = @NacosProperties(serverAddr = "${server.addr}"))
 public class NacosConfigListenerMethodProcessorTest extends AbstractNacosHttpServerTestExecutionListener {
 
-    @Autowired
-    private Listeners listeners;
-
     @Bean(name = ApplicationContextHolder.BEAN_NAME)
     public ApplicationContextHolder applicationContextHolder(ApplicationContext applicationContext) {
         ApplicationContextHolder applicationContextHolder = new ApplicationContextHolder();
@@ -79,10 +76,8 @@ public class NacosConfigListenerMethodProcessorTest extends AbstractNacosHttpSer
         return applicationContextHolder;
     }
 
-    @Override
-    protected String getServerAddressPropertyName() {
-        return "server.addr";
-    }
+    @Autowired
+    private Listeners listeners;
 
     @NacosInjected
     private ConfigService configService;
@@ -113,8 +108,11 @@ public class NacosConfigListenerMethodProcessorTest extends AbstractNacosHttpSer
     }
 
     @Test
-    public void testPublishConfig() throws NacosException {
+    public void testPublishConfig() throws NacosException, InterruptedException {
         configService.publishConfig(DATA_ID, DEFAULT_GROUP, "9527");
+
+        Thread.sleep(3000);
+
         assertNull(listeners.getIntegerValue()); // asserts true
         assertEquals(Double.valueOf(9527), listeners.getDoubleValue());   // asserts true
     }
@@ -131,4 +129,8 @@ public class NacosConfigListenerMethodProcessorTest extends AbstractNacosHttpSer
         assertEquals("mercyblitz", user.getName());
     }
 
+    @Override
+    protected String getServerAddressPropertyName() {
+        return "server.addr";
+    }
 }

--- a/nacos-spring-context/src/test/java/com/alibaba/nacos/spring/context/annotation/config/NacosConfigListenerMethodProcessorTest.java
+++ b/nacos-spring-context/src/test/java/com/alibaba/nacos/spring/context/annotation/config/NacosConfigListenerMethodProcessorTest.java
@@ -17,21 +17,30 @@
 package com.alibaba.nacos.spring.context.annotation.config;
 
 import com.alibaba.nacos.api.annotation.NacosInjected;
+import com.alibaba.nacos.api.annotation.NacosProperties;
 import com.alibaba.nacos.api.config.ConfigService;
 import com.alibaba.nacos.api.config.annotation.NacosConfigListener;
 import com.alibaba.nacos.api.config.listener.AbstractListener;
 import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.spring.beans.factory.annotation.AnnotationNacosInjectedBeanPostProcessor;
 import com.alibaba.nacos.spring.beans.factory.annotation.ConfigServiceBeanBuilder;
+import com.alibaba.nacos.spring.context.annotation.EnableNacos;
 import com.alibaba.nacos.spring.convert.converter.config.UserNacosConfigConverter;
+import com.alibaba.nacos.spring.factory.ApplicationContextHolder;
+import com.alibaba.nacos.spring.test.AbstractNacosHttpServerTestExecutionListener;
 import com.alibaba.nacos.spring.test.Listeners;
 import com.alibaba.nacos.spring.test.TestConfiguration;
 import com.alibaba.nacos.spring.test.User;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
+import org.springframework.test.context.support.DirtiesContextTestExecutionListener;
 
 import javax.annotation.PostConstruct;
 
@@ -48,7 +57,6 @@ import static org.junit.Assert.assertNull;
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = {
-        TestConfiguration.class,
         Listeners.class,
         ConfigServiceBeanBuilder.class,
         AnnotationNacosInjectedBeanPostProcessor.class,
@@ -56,10 +64,25 @@ import static org.junit.Assert.assertNull;
         NacosConfigListenerMethodProcessorTest.class,
 
 })
-public class NacosConfigListenerMethodProcessorTest {
+@TestExecutionListeners({DependencyInjectionTestExecutionListener.class,
+        DirtiesContextTestExecutionListener.class, NacosConfigListenerMethodProcessorTest.class})
+@EnableNacos(globalProperties = @NacosProperties(serverAddr = "${server.addr}"))
+public class NacosConfigListenerMethodProcessorTest extends AbstractNacosHttpServerTestExecutionListener {
 
     @Autowired
     private Listeners listeners;
+
+    @Bean(name = ApplicationContextHolder.BEAN_NAME)
+    public ApplicationContextHolder applicationContextHolder(ApplicationContext applicationContext) {
+        ApplicationContextHolder applicationContextHolder = new ApplicationContextHolder();
+        applicationContextHolder.setApplicationContext(applicationContext);
+        return applicationContextHolder;
+    }
+
+    @Override
+    protected String getServerAddressPropertyName() {
+        return "server.addr";
+    }
 
     @NacosInjected
     private ConfigService configService;

--- a/nacos-spring-context/src/test/java/com/alibaba/nacos/spring/context/annotation/config/NacosPropertySourcePostProcessorTest.java
+++ b/nacos-spring-context/src/test/java/com/alibaba/nacos/spring/context/annotation/config/NacosPropertySourcePostProcessorTest.java
@@ -16,22 +16,43 @@
  */
 package com.alibaba.nacos.spring.context.annotation.config;
 
+import com.alibaba.nacos.api.annotation.NacosInjected;
+import com.alibaba.nacos.api.annotation.NacosProperties;
 import com.alibaba.nacos.api.config.ConfigService;
 import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.embedded.web.server.EmbeddedNacosHttpServer;
 import com.alibaba.nacos.spring.beans.factory.annotation.AnnotationNacosInjectedBeanPostProcessor;
 import com.alibaba.nacos.spring.beans.factory.annotation.ConfigServiceBeanBuilder;
+import com.alibaba.nacos.spring.context.annotation.EnableNacos;
 import com.alibaba.nacos.spring.core.env.AnnotationNacosPropertySourceBuilder;
 import com.alibaba.nacos.spring.core.env.NacosPropertySourcePostProcessor;
+import com.alibaba.nacos.spring.factory.ApplicationContextHolder;
+import com.alibaba.nacos.spring.test.AbstractNacosHttpServerTestExecutionListener;
 import com.alibaba.nacos.spring.test.MockConfigService;
+import com.alibaba.nacos.spring.test.TestApplicationHolder;
 import com.alibaba.nacos.spring.test.TestConfiguration;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.PropertySource;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
+import org.springframework.test.context.support.DirtiesContextTestExecutionListener;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import static com.alibaba.nacos.api.common.Constants.DEFAULT_GROUP;
+import static com.alibaba.nacos.embedded.web.server.NacosConfigHttpHandler.CONTENT_PARAM_NAME;
+import static com.alibaba.nacos.embedded.web.server.NacosConfigHttpHandler.DATA_ID_PARAM_NAME;
+import static com.alibaba.nacos.embedded.web.server.NacosConfigHttpHandler.GROUP_ID_PARAM_NAME;
 import static com.alibaba.nacos.spring.test.MockNacosServiceFactory.DATA_ID;
 import static com.alibaba.nacos.spring.test.TestConfiguration.CONFIG_SERVICE_BEAN_NAME;
 import static org.springframework.core.env.StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME;
@@ -44,7 +65,14 @@ import static org.springframework.core.env.StandardEnvironment.SYSTEM_PROPERTIES
  * @ee NacosPropertySourcePostProcessor
  * @since 0.1.0
  */
-public class NacosPropertySourcePostProcessorTest {
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = {
+        NacosPropertySourcePostProcessorTest.class
+})
+@TestExecutionListeners({DependencyInjectionTestExecutionListener.class,
+        DirtiesContextTestExecutionListener.class, NacosPropertySourcePostProcessorTest.class})
+@EnableNacos(globalProperties = @NacosProperties(serverAddr = "${server.addr}"))
+public class NacosPropertySourcePostProcessorTest extends AbstractNacosHttpServerTestExecutionListener {
 
     private static final String TEST_PROPERTY_NAME = "user.name";
 
@@ -84,6 +112,29 @@ public class NacosPropertySourcePostProcessorTest {
 
     }
 
+    @Override
+    public void init(EmbeddedNacosHttpServer httpServer) {
+        Map<String, String> config = new HashMap<String, String>(1);
+        config.put(DATA_ID_PARAM_NAME, DATA_ID);
+        config.put(GROUP_ID_PARAM_NAME, DEFAULT_GROUP);
+        config.put(CONTENT_PARAM_NAME, TEST_CONTENT);
+        httpServer.initConfig(config);
+    }
+
+    @Override
+    protected String getServerAddressPropertyName() {
+        return "server.addr";
+    }
+
+    @Bean(name = ApplicationContextHolder.BEAN_NAME)
+    public ApplicationContextHolder applicationContextHolder(ApplicationContext applicationContext) {
+        ApplicationContextHolder applicationContextHolder = new ApplicationContextHolder();
+        applicationContextHolder.setApplicationContext(applicationContext);
+        return applicationContextHolder;
+    }
+
+    @NacosInjected
+    private ConfigService configService;
 
     @Test
     public void testFirstOrder() throws NacosException {
@@ -149,15 +200,13 @@ public class NacosPropertySourcePostProcessorTest {
 
         ConfigurableListableBeanFactory beanFactory = context.getBeanFactory();
 
-        ConfigService configService = new MockConfigService();
-
         configService.publishConfig(dataId, groupId, content);
 
         beanFactory.registerSingleton(CONFIG_SERVICE_BEAN_NAME, configService);
 
-        context.register(TestConfiguration.class, AnnotationNacosInjectedBeanPostProcessor.class,
+        context.register(AnnotationNacosInjectedBeanPostProcessor.class,
                 NacosPropertySourcePostProcessor.class, ConfigServiceBeanBuilder.class,
-                AnnotationNacosPropertySourceBuilder.class);
+                AnnotationNacosPropertySourceBuilder.class, TestConfiguration.class, TestApplicationHolder.class);
         return context;
     }
 }

--- a/nacos-spring-context/src/test/java/com/alibaba/nacos/spring/context/annotation/config/NacosPropertySourcePostProcessorTest.java
+++ b/nacos-spring-context/src/test/java/com/alibaba/nacos/spring/context/annotation/config/NacosPropertySourcePostProcessorTest.java
@@ -28,7 +28,6 @@ import com.alibaba.nacos.spring.core.env.AnnotationNacosPropertySourceBuilder;
 import com.alibaba.nacos.spring.core.env.NacosPropertySourcePostProcessor;
 import com.alibaba.nacos.spring.factory.ApplicationContextHolder;
 import com.alibaba.nacos.spring.test.AbstractNacosHttpServerTestExecutionListener;
-import com.alibaba.nacos.spring.test.MockConfigService;
 import com.alibaba.nacos.spring.test.TestApplicationHolder;
 import com.alibaba.nacos.spring.test.TestConfiguration;
 import org.junit.Assert;

--- a/nacos-spring-context/src/test/java/com/alibaba/nacos/spring/context/annotation/config/NacosPropertySourceTest.java
+++ b/nacos-spring-context/src/test/java/com/alibaba/nacos/spring/context/annotation/config/NacosPropertySourceTest.java
@@ -20,6 +20,7 @@ import com.alibaba.nacos.api.annotation.NacosInjected;
 import com.alibaba.nacos.api.annotation.NacosProperties;
 import com.alibaba.nacos.api.config.ConfigService;
 import com.alibaba.nacos.api.config.annotation.NacosValue;
+import com.alibaba.nacos.api.config.listener.Listener;
 import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.embedded.web.server.EmbeddedNacosHttpServer;
 import com.alibaba.nacos.spring.context.annotation.EnableNacos;
@@ -40,6 +41,7 @@ import org.springframework.test.context.support.DirtiesContextTestExecutionListe
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.Executor;
 
 import static com.alibaba.nacos.api.common.Constants.DEFAULT_GROUP;
 import static com.alibaba.nacos.embedded.web.server.NacosConfigHttpHandler.CONTENT_PARAM_NAME;
@@ -56,10 +58,10 @@ import static com.alibaba.nacos.embedded.web.server.NacosConfigHttpHandler.GROUP
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = {
-    NacosPropertySourceTest.class
+        NacosPropertySourceTest.class
 })
 @TestExecutionListeners({DependencyInjectionTestExecutionListener.class,
-    DirtiesContextTestExecutionListener.class, NacosPropertySourceTest.class})
+        DirtiesContextTestExecutionListener.class, NacosPropertySourceTest.class})
 @NacosPropertySource(dataId = NacosPropertySourceTest.DATA_ID, autoRefreshed = true)
 @EnableNacos(globalProperties = @NacosProperties(serverAddr = "${server.addr}"))
 @Component
@@ -87,10 +89,9 @@ public class NacosPropertySourceTest extends AbstractNacosHttpServerTestExecutio
         config.put(DATA_ID_PARAM_NAME, DATA_ID);
         config.put(GROUP_ID_PARAM_NAME, DEFAULT_GROUP);
 
-
         config.put(CONTENT_PARAM_NAME,
-            "app.name=" + APP_NAME + LINE_SEPARATOR + "app.nacosFieldIntValueAutoRefreshed=" + VALUE_1 + LINE_SEPARATOR
-                + "app.nacosMethodIntValueAutoRefreshed=" + VALUE_2);
+                "app.name=" + APP_NAME + LINE_SEPARATOR + "app.nacosFieldIntValueAutoRefreshed=" + VALUE_1 + LINE_SEPARATOR
+                        + "app.nacosMethodIntValueAutoRefreshed=" + VALUE_2);
         httpServer.initConfig(config);
     }
 
@@ -153,6 +154,7 @@ public class NacosPropertySourceTest extends AbstractNacosHttpServerTestExecutio
 
     @Test
     public void testValue() throws NacosException, InterruptedException {
+
         Assert.assertEquals(APP_NAME, app.name);
 
         Assert.assertEquals(APP_NAME, app.nameWithDefaultValue);
@@ -174,10 +176,10 @@ public class NacosPropertySourceTest extends AbstractNacosHttpServerTestExecutio
         Assert.assertEquals(VALUE_2, app.nacosMethodIntValueAutoRefreshed);
 
         configService.publishConfig(DATA_ID, DEFAULT_GROUP,
-            "app.name=" + ANOTHER_APP_NAME + LINE_SEPARATOR + "app.nacosFieldIntValueAutoRefreshed=" + VALUE_3
-                + LINE_SEPARATOR + "app.nacosMethodIntValueAutoRefreshed=" + VALUE_4);
+                "app.name=" + ANOTHER_APP_NAME + LINE_SEPARATOR + "app.nacosFieldIntValueAutoRefreshed=" + VALUE_3
+                        + LINE_SEPARATOR + "app.nacosMethodIntValueAutoRefreshed=" + VALUE_4);
 
-        Thread.sleep(1000);
+        Thread.sleep(2000);
 
         Assert.assertEquals(APP_NAME, app.name);
 

--- a/nacos-spring-context/src/test/java/com/alibaba/nacos/spring/context/annotation/config/NacosPropertySourceXMLTest.java
+++ b/nacos-spring-context/src/test/java/com/alibaba/nacos/spring/context/annotation/config/NacosPropertySourceXMLTest.java
@@ -1,0 +1,124 @@
+///*
+// * Licensed to the Apache Software Foundation (ASF) under one or more
+// * contributor license agreements.  See the NOTICE file distributed with
+// * this work for additional information regarding copyright ownership.
+// * The ASF licenses this file to You under the Apache License, Version 2.0
+// * (the "License"); you may not use this file except in compliance with
+// * the License.  You may obtain a copy of the License at
+// *
+// *     http://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing, software
+// * distributed under the License is distributed on an "AS IS" BASIS,
+// * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// * See the License for the specific language governing permissions and
+// * limitations under the License.
+// */
+//package com.alibaba.nacos.spring.context.annotation.config;
+//
+//import com.alibaba.nacos.api.annotation.NacosInjected;
+//import com.alibaba.nacos.api.annotation.NacosProperties;
+//import com.alibaba.nacos.api.config.ConfigService;
+//import com.alibaba.nacos.api.config.annotation.NacosValue;
+//import com.alibaba.nacos.api.exception.NacosException;
+//import com.alibaba.nacos.embedded.web.server.EmbeddedNacosHttpServer;
+//import com.alibaba.nacos.spring.context.annotation.EnableNacos;
+//import com.alibaba.nacos.spring.test.AbstractNacosHttpServerTestExecutionListener;
+//import com.alibaba.nacos.spring.test.XmlApp2;
+//import org.junit.Assert;
+//import org.junit.Test;
+//import org.junit.runner.RunWith;
+//import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.context.annotation.Bean;
+//import org.springframework.stereotype.Component;
+//import org.springframework.test.context.ContextConfiguration;
+//import org.springframework.test.context.TestExecutionListeners;
+//import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+//import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
+//import org.springframework.test.context.support.DirtiesContextTestExecutionListener;
+//
+//import java.util.HashMap;
+//import java.util.Map;
+//
+//import static com.alibaba.nacos.api.common.Constants.DEFAULT_GROUP;
+//import static com.alibaba.nacos.embedded.web.server.NacosConfigHttpHandler.CONTENT_PARAM_NAME;
+//import static com.alibaba.nacos.embedded.web.server.NacosConfigHttpHandler.DATA_ID_PARAM_NAME;
+//import static com.alibaba.nacos.embedded.web.server.NacosConfigHttpHandler.GROUP_ID_PARAM_NAME;
+//import static com.alibaba.nacos.spring.test.MockNacosServiceFactory.GROUP_ID;
+//
+///**
+// * @author <a href="mailto:liaochunyhm@live.com">liaochuntao</a>
+// * @since
+// */
+//@RunWith(SpringJUnit4ClassRunner.class)
+//@ContextConfiguration(classes = {
+//        NacosPropertySourceXMLTest.class
+//})
+//@TestExecutionListeners({DependencyInjectionTestExecutionListener.class,
+//        DirtiesContextTestExecutionListener.class, NacosPropertySourceXMLTest.class})
+//@NacosPropertySource(dataId = XmlApp2.DATA_ID_XML, autoRefreshed = true, type = "xml")
+//@EnableNacos(globalProperties = @NacosProperties(serverAddr = "${server.addr}"))
+//public class NacosPropertySourceXMLTest extends AbstractNacosHttpServerTestExecutionListener {
+//
+//
+//    private String xml =
+//                    "<xml>" +
+//                    "<students>" +
+//                    "<student>" +
+//                    "<name>lct-1</name>" +
+//                    "<num>1006010022</num>" +
+//                    "</student>" +
+//                    "<student>" +
+//                    "<name>lct-2</name>" +
+//                    "<num>1006010033</num>" +
+//                    "</student>" +
+//                    "<student>" +
+//                    "<name>lct-3</name>" +
+//                    "<num>1006010044</num>" +
+//                    "</student>" +
+//                    "<student>" +
+//                    "<name>lct-4</name>" +
+//                    "<num>1006010055</num>" +
+//                    "</student>" +
+//                    "</students>" +
+//                    "</xml>";
+//
+//    private final String except = "XmlApp2{students=[Student{name='lct-1', num='1006010022'}, Student{name='lct-3', num='1006010044'}, Student{name='lct-4', num='1006010055'}]}";
+//
+//    @Override
+//    public void init(EmbeddedNacosHttpServer httpServer) {
+//        Map<String, String> config = new HashMap<String, String>(1);
+//        config.put(DATA_ID_PARAM_NAME, XmlApp2.DATA_ID_XML);
+//        config.put(GROUP_ID_PARAM_NAME, DEFAULT_GROUP);
+//        config.put(CONTENT_PARAM_NAME, xml);
+//
+//        httpServer.initConfig(config);
+//    }
+//
+//    @Override
+//    protected String getServerAddressPropertyName() {
+//        return "server.addr";
+//    }
+//
+//    @Bean
+//    public XmlApp2 xmlApp() {
+//        return new XmlApp2();
+//    }
+//
+//    @NacosInjected
+//    private ConfigService configService;
+//
+//    @Autowired
+//    private XmlApp2 xmlApp;
+//
+//    @Test
+//    public void testValue() throws NacosException, InterruptedException {
+//
+//        configService.publishConfig(XmlApp2.DATA_ID_XML, GROUP_ID, xml);
+//
+//        Thread.sleep(2000);
+//
+//        Assert.assertEquals(except, xmlApp.toString());
+//    }
+//
+//}

--- a/nacos-spring-context/src/test/java/com/alibaba/nacos/spring/context/annotation/config/NacosPropertySourceYamlTest.java
+++ b/nacos-spring-context/src/test/java/com/alibaba/nacos/spring/context/annotation/config/NacosPropertySourceYamlTest.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.nacos.spring.context.annotation.config;
+
+import com.alibaba.nacos.api.annotation.NacosInjected;
+import com.alibaba.nacos.api.annotation.NacosProperties;
+import com.alibaba.nacos.api.config.ConfigService;
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.embedded.web.server.EmbeddedNacosHttpServer;
+import com.alibaba.nacos.spring.context.annotation.EnableNacos;
+import com.alibaba.nacos.spring.test.AbstractNacosHttpServerTestExecutionListener;
+import com.alibaba.nacos.spring.test.XmlApp2;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
+import org.springframework.test.context.support.DirtiesContextTestExecutionListener;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.alibaba.nacos.api.common.Constants.DEFAULT_GROUP;
+import static com.alibaba.nacos.embedded.web.server.NacosConfigHttpHandler.CONTENT_PARAM_NAME;
+import static com.alibaba.nacos.embedded.web.server.NacosConfigHttpHandler.DATA_ID_PARAM_NAME;
+import static com.alibaba.nacos.embedded.web.server.NacosConfigHttpHandler.GROUP_ID_PARAM_NAME;
+import static com.alibaba.nacos.spring.test.MockNacosServiceFactory.GROUP_ID;
+
+/**
+ * @author <a href="mailto:liaochunyhm@live.com">liaochuntao</a>
+ * @since
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = {
+        NacosPropertySourceYamlTest.class
+})
+@TestExecutionListeners({DependencyInjectionTestExecutionListener.class,
+        DirtiesContextTestExecutionListener.class, NacosPropertySourceYamlTest.class})
+@NacosPropertySource(dataId = XmlApp2.DATA_ID_XML, autoRefreshed = true, type = "yaml")
+@EnableNacos(globalProperties = @NacosProperties(serverAddr = "${server.addr}"))
+public class NacosPropertySourceYamlTest extends AbstractNacosHttpServerTestExecutionListener {
+
+    private String yaml = "students:\n" +
+            "    - {name: lct-1,num: 12}\n" +
+            "    - {name: lct-2,num: 13}\n" +
+            "    - {name: lct-3,num: 14}";
+
+    private String except = "XmlApp2{students=[Student{name='lct-1', num='12'}, Student{name='lct-2', num='13'}, Student{name='lct-3', num='14'}]}";
+
+    @Override
+    public void init(EmbeddedNacosHttpServer httpServer) {
+        Map<String, String> config = new HashMap<String, String>(1);
+        config.put(DATA_ID_PARAM_NAME, XmlApp2.DATA_ID_XML);
+        config.put(GROUP_ID_PARAM_NAME, DEFAULT_GROUP);
+        config.put(CONTENT_PARAM_NAME, yaml);
+
+        httpServer.initConfig(config);
+    }
+
+    @Bean
+    public XmlApp2 xmlApp() {
+        return new XmlApp2();
+    }
+
+    @NacosInjected
+    private ConfigService configService;
+
+    @Autowired
+    private XmlApp2 xmlApp;
+
+    @Override
+    protected String getServerAddressPropertyName() {
+        return "server.addr";
+    }
+
+    @Test
+    public void testValue() throws NacosException, InterruptedException {
+
+        configService.publishConfig(XmlApp2.DATA_ID_XML, GROUP_ID, yaml);
+
+        Thread.sleep(2000);
+
+        System.out.println(xmlApp.toString());
+
+        Assert.assertEquals(except, xmlApp.toString());
+
+    }
+}

--- a/nacos-spring-context/src/test/java/com/alibaba/nacos/spring/context/config/xml/NacosAnnotationDrivenBeanDefinitionParserTest.java
+++ b/nacos-spring-context/src/test/java/com/alibaba/nacos/spring/context/config/xml/NacosAnnotationDrivenBeanDefinitionParserTest.java
@@ -22,6 +22,7 @@ import com.alibaba.nacos.spring.beans.factory.annotation.AnnotationNacosInjected
 import com.alibaba.nacos.spring.context.annotation.config.NacosConfigListenerMethodProcessor;
 import com.alibaba.nacos.spring.context.properties.config.NacosConfigurationPropertiesBindingPostProcessor;
 import com.alibaba.nacos.spring.core.env.NacosPropertySourcePostProcessor;
+import com.alibaba.nacos.spring.factory.ApplicationContextHolder;
 import com.alibaba.nacos.spring.factory.CacheableEventPublishingNacosServiceFactory;
 import com.alibaba.nacos.spring.factory.NacosServiceFactory;
 import com.alibaba.nacos.spring.util.NacosBeanUtils;
@@ -65,8 +66,8 @@ public class NacosAnnotationDrivenBeanDefinitionParserTest {
     private Properties globalProperties;
 
     @Autowired
-    @Qualifier(CacheableEventPublishingNacosServiceFactory.BEAN_NAME)
-    private NacosServiceFactory nacosServiceFactory;
+    @Qualifier(ApplicationContextHolder.BEAN_NAME)
+    private ApplicationContextHolder contextHolder;
 
     @Autowired
     @Qualifier(AnnotationNacosInjectedBeanPostProcessor.BEAN_NAME)
@@ -90,7 +91,7 @@ public class NacosAnnotationDrivenBeanDefinitionParserTest {
     @Test
     public void test() {
         Assert.assertNotNull(globalProperties);
-        Assert.assertNotNull(nacosServiceFactory);
+        Assert.assertNotNull(contextHolder);
         Assert.assertNotNull(annotationNacosInjectedBeanPostProcessor);
         Assert.assertNotNull(nacosConfigurationPropertiesBindingPostProcessor);
         Assert.assertNotNull(nacosConfigListenerMethodProcessor);

--- a/nacos-spring-context/src/test/java/com/alibaba/nacos/spring/context/properties/config/NacosConfigurationPropertiesBindingPostProcessorTest.java
+++ b/nacos-spring-context/src/test/java/com/alibaba/nacos/spring/context/properties/config/NacosConfigurationPropertiesBindingPostProcessorTest.java
@@ -16,6 +16,7 @@
  */
 package com.alibaba.nacos.spring.context.properties.config;
 
+import com.alibaba.fastjson.JSON;
 import com.alibaba.nacos.api.annotation.NacosInjected;
 import com.alibaba.nacos.api.annotation.NacosProperties;
 import com.alibaba.nacos.api.config.ConfigService;
@@ -23,6 +24,7 @@ import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.spring.context.annotation.EnableNacos;
 import com.alibaba.nacos.spring.test.AbstractNacosHttpServerTestExecutionListener;
 import com.alibaba.nacos.spring.test.Config;
+import com.alibaba.nacos.spring.test.TestOrder;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,6 +35,8 @@ import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
 import org.springframework.test.context.support.DirtiesContextTestExecutionListener;
+
+import java.util.HashMap;
 
 import static com.alibaba.nacos.spring.test.MockNacosServiceFactory.DATA_ID;
 import static com.alibaba.nacos.spring.test.MockNacosServiceFactory.GROUP_ID;
@@ -65,6 +69,14 @@ public class NacosConfigurationPropertiesBindingPostProcessorTest extends Abstra
         return new Config();
     }
 
+    @Autowired
+    private TestOrder testOrder;
+
+    @Bean
+    public TestOrder order() {
+        return new TestOrder();
+    }
+
     @Test
     public void test() throws NacosException, InterruptedException {
 
@@ -89,6 +101,27 @@ public class NacosConfigurationPropertiesBindingPostProcessorTest extends Abstra
         Assert.assertEquals(Float.valueOf(1234.5f), config.getFloatData());
         Assert.assertNull(config.getIntData());
 
+    }
+
+    @Test
+    public void test1() throws NacosException, InterruptedException {
+
+        TestOrder order = new TestOrder();
+        order.setAddId("1");
+        order.setAddress("1");
+        HashMap<String, String> map = new HashMap<String, String>();
+        map.put("111", "111");
+        order.setFdOrderFoodId(map);
+        order.setfOrderCost("1");
+        order.setfOrderCreateTime("1");
+        order.setfOrderMailCost("1");
+        order.setfOrderSubPrice("1");
+
+        configService.publishConfig(DATA_ID, GROUP_ID, JSON.toJSONString(order));
+
+        Thread.sleep(2000);
+
+        System.out.println(testOrder);
     }
 
     @Override

--- a/nacos-spring-context/src/test/java/com/alibaba/nacos/spring/context/properties/config/NacosConfigurationPropertiesBindingPostProcessorTest.java
+++ b/nacos-spring-context/src/test/java/com/alibaba/nacos/spring/context/properties/config/NacosConfigurationPropertiesBindingPostProcessorTest.java
@@ -20,12 +20,9 @@ import com.alibaba.nacos.api.annotation.NacosInjected;
 import com.alibaba.nacos.api.annotation.NacosProperties;
 import com.alibaba.nacos.api.config.ConfigService;
 import com.alibaba.nacos.api.exception.NacosException;
-import com.alibaba.nacos.spring.beans.factory.annotation.AnnotationNacosInjectedBeanPostProcessor;
-import com.alibaba.nacos.spring.beans.factory.annotation.ConfigServiceBeanBuilder;
 import com.alibaba.nacos.spring.context.annotation.EnableNacos;
 import com.alibaba.nacos.spring.test.AbstractNacosHttpServerTestExecutionListener;
 import com.alibaba.nacos.spring.test.Config;
-import com.alibaba.nacos.spring.test.TestConfiguration;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -68,15 +65,12 @@ public class NacosConfigurationPropertiesBindingPostProcessorTest extends Abstra
         return new Config();
     }
 
-    @Override
-    protected String getServerAddressPropertyName() {
-        return "server.addr";
-    }
-
     @Test
-    public void test() throws NacosException {
+    public void test() throws NacosException, InterruptedException {
 
         configService.publishConfig(DATA_ID, GROUP_ID, TEST_CONFIG);
+
+        Thread.sleep(2000);
 
         Assert.assertEquals(1, config.getId());
         Assert.assertEquals("mercyblitz", config.getName());
@@ -87,6 +81,8 @@ public class NacosConfigurationPropertiesBindingPostProcessorTest extends Abstra
         // Publishing config emits change
         configService.publishConfig(DATA_ID, GROUP_ID, MODIFIED_TEST_CONTEXT);
 
+        Thread.sleep(2000);
+
         Assert.assertEquals(1, config.getId());
         Assert.assertEquals("mercyblitz@gmail.com", config.getName());
         Assert.assertTrue(9527 == config.getValue());
@@ -95,4 +91,8 @@ public class NacosConfigurationPropertiesBindingPostProcessorTest extends Abstra
 
     }
 
+    @Override
+    protected String getServerAddressPropertyName() {
+        return "server.addr";
+    }
 }

--- a/nacos-spring-context/src/test/java/com/alibaba/nacos/spring/context/properties/config/NacosConfigurationPropertiesBindingPostProcessorTest.java
+++ b/nacos-spring-context/src/test/java/com/alibaba/nacos/spring/context/properties/config/NacosConfigurationPropertiesBindingPostProcessorTest.java
@@ -17,10 +17,13 @@
 package com.alibaba.nacos.spring.context.properties.config;
 
 import com.alibaba.nacos.api.annotation.NacosInjected;
+import com.alibaba.nacos.api.annotation.NacosProperties;
 import com.alibaba.nacos.api.config.ConfigService;
 import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.spring.beans.factory.annotation.AnnotationNacosInjectedBeanPostProcessor;
 import com.alibaba.nacos.spring.beans.factory.annotation.ConfigServiceBeanBuilder;
+import com.alibaba.nacos.spring.context.annotation.EnableNacos;
+import com.alibaba.nacos.spring.test.AbstractNacosHttpServerTestExecutionListener;
 import com.alibaba.nacos.spring.test.Config;
 import com.alibaba.nacos.spring.test.TestConfiguration;
 import org.junit.Assert;
@@ -29,7 +32,10 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
+import org.springframework.test.context.support.DirtiesContextTestExecutionListener;
 
 import static com.alibaba.nacos.spring.test.MockNacosServiceFactory.DATA_ID;
 import static com.alibaba.nacos.spring.test.MockNacosServiceFactory.GROUP_ID;
@@ -44,13 +50,12 @@ import static com.alibaba.nacos.spring.test.TestConfiguration.TEST_CONFIG;
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = {
-        TestConfiguration.class,
-        ConfigServiceBeanBuilder.class,
-        NacosConfigurationPropertiesBindingPostProcessor.class,
-        AnnotationNacosInjectedBeanPostProcessor.class,
         NacosConfigurationPropertiesBindingPostProcessorTest.class
 })
-public class NacosConfigurationPropertiesBindingPostProcessorTest {
+@TestExecutionListeners({DependencyInjectionTestExecutionListener.class,
+        DirtiesContextTestExecutionListener.class, NacosConfigurationPropertiesBindingPostProcessorTest.class})
+@EnableNacos(globalProperties = @NacosProperties(serverAddr = "${server.addr}"))
+public class NacosConfigurationPropertiesBindingPostProcessorTest extends AbstractNacosHttpServerTestExecutionListener {
 
     @Autowired
     private Config config;
@@ -61,6 +66,11 @@ public class NacosConfigurationPropertiesBindingPostProcessorTest {
     @Bean
     public Config config() {
         return new Config();
+    }
+
+    @Override
+    protected String getServerAddressPropertyName() {
+        return "server.addr";
     }
 
     @Test

--- a/nacos-spring-context/src/test/java/com/alibaba/nacos/spring/factory/CacheableEventPublishingNacosServiceFactoryTest.java
+++ b/nacos-spring-context/src/test/java/com/alibaba/nacos/spring/factory/CacheableEventPublishingNacosServiceFactoryTest.java
@@ -20,6 +20,7 @@ import com.alibaba.nacos.api.PropertyKeyConst;
 import com.alibaba.nacos.api.config.ConfigService;
 import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.naming.NamingService;
+import com.alibaba.nacos.spring.test.TestApplicationHolder;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -43,6 +44,7 @@ import static com.alibaba.nacos.spring.util.NacosBeanUtils.NACOS_CONFIG_LISTENER
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = {
+        TestApplicationHolder.class,
         CacheableEventPublishingNacosServiceFactory.class,
         CacheableEventPublishingNacosServiceFactoryTest.class
 })

--- a/nacos-spring-context/src/test/java/com/alibaba/nacos/spring/test/MockNacosServiceFactory.java
+++ b/nacos-spring-context/src/test/java/com/alibaba/nacos/spring/test/MockNacosServiceFactory.java
@@ -20,6 +20,7 @@ import com.alibaba.nacos.api.config.ConfigService;
 import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.naming.NamingMaintainService;
 import com.alibaba.nacos.api.naming.NamingService;
+import com.alibaba.nacos.client.config.NacosConfigService;
 import com.alibaba.nacos.spring.factory.NacosServiceFactory;
 import org.mockito.Mockito;
 
@@ -105,8 +106,7 @@ public class MockNacosServiceFactory implements NacosServiceFactory {
         String key = identify(properties);
         ConfigService configService = configServiceCache.get(key);
         if (configService == null) {
-            configService = new MockConfigService();
-            configServiceCache.put(key, configService);
+            configService = new NacosConfigService(properties);
         }
         return configService;
     }
@@ -135,4 +135,5 @@ public class MockNacosServiceFactory implements NacosServiceFactory {
     public Collection<NamingMaintainService> getNamingMaintainService() {
         return Collections.emptyList();
     }
+
 }

--- a/nacos-spring-context/src/test/java/com/alibaba/nacos/spring/test/MockNacosServiceFactory.java
+++ b/nacos-spring-context/src/test/java/com/alibaba/nacos/spring/test/MockNacosServiceFactory.java
@@ -18,6 +18,7 @@ package com.alibaba.nacos.spring.test;
 
 import com.alibaba.nacos.api.config.ConfigService;
 import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.naming.NamingMaintainService;
 import com.alibaba.nacos.api.naming.NamingService;
 import com.alibaba.nacos.spring.factory.NacosServiceFactory;
 import org.mockito.Mockito;
@@ -116,12 +117,22 @@ public class MockNacosServiceFactory implements NacosServiceFactory {
     }
 
     @Override
+    public NamingMaintainService createNamingMaintainService(Properties properties) throws NacosException {
+        return Mockito.mock(NamingMaintainService.class);
+    }
+
+    @Override
     public Collection<ConfigService> getConfigServices() {
         return configServiceCache.values();
     }
 
     @Override
     public Collection<NamingService> getNamingServices() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Collection<NamingMaintainService> getNamingMaintainService() {
         return Collections.emptyList();
     }
 }

--- a/nacos-spring-context/src/test/java/com/alibaba/nacos/spring/test/TestApplicationHolder.java
+++ b/nacos-spring-context/src/test/java/com/alibaba/nacos/spring/test/TestApplicationHolder.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.nacos.spring.test;
+
+import com.alibaba.nacos.spring.factory.ApplicationContextHolder;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @author <a href="mailto:liaochunyhm@live.com">liaochuntao</a>
+ * @since
+ */
+@Configuration
+public class TestApplicationHolder {
+
+    @Bean(name = ApplicationContextHolder.BEAN_NAME)
+    public ApplicationContextHolder applicationContextHolder(ApplicationContext applicationContext) {
+        ApplicationContextHolder applicationContextHolder = new ApplicationContextHolder();
+        applicationContextHolder.setApplicationContext(applicationContext);
+        return applicationContextHolder;
+    }
+
+}

--- a/nacos-spring-context/src/test/java/com/alibaba/nacos/spring/test/TestConfiguration.java
+++ b/nacos-spring-context/src/test/java/com/alibaba/nacos/spring/test/TestConfiguration.java
@@ -16,12 +16,14 @@
  */
 package com.alibaba.nacos.spring.test;
 
+import com.alibaba.nacos.api.PropertyKeyConst;
 import com.alibaba.nacos.api.config.ConfigService;
 import com.alibaba.nacos.spring.factory.CacheableEventPublishingNacosServiceFactory;
 import com.alibaba.nacos.spring.factory.NacosServiceFactory;
 import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.util.StringUtils;
 
 import java.util.Map;
 import java.util.Properties;
@@ -55,22 +57,10 @@ public class TestConfiguration {
     @Bean(name = GLOBAL_NACOS_PROPERTIES_BEAN_NAME)
     public Properties globalNacosProperties() {
         Properties properties = new Properties();
-        return properties;
-    }
-
-    @Bean(name = CacheableEventPublishingNacosServiceFactory.BEAN_NAME)
-    public NacosServiceFactory nacosServiceFactory(ListableBeanFactory beanFactory) {
-
-        MockNacosServiceFactory nacosServiceFactory = new MockNacosServiceFactory();
-
-        Map<String, ConfigService> configServices = beanFactory.getBeansOfType(ConfigService.class);
-
-        if (configServices.containsKey(CONFIG_SERVICE_BEAN_NAME)) {
-            ConfigService configService = configServices.get(CONFIG_SERVICE_BEAN_NAME);
-            nacosServiceFactory.setConfigService(configService);
+        if (!StringUtils.isEmpty(System.getProperty("server.addr"))) {
+            properties.put(PropertyKeyConst.SERVER_ADDR, System.getProperty("server.addr"));
         }
-
-        return nacosServiceFactory;
+        return properties;
     }
 
 }

--- a/nacos-spring-context/src/test/java/com/alibaba/nacos/spring/test/TestConfiguration.java
+++ b/nacos-spring-context/src/test/java/com/alibaba/nacos/spring/test/TestConfiguration.java
@@ -54,6 +54,7 @@ public class TestConfiguration {
             "name = mercyblitz@gmail.com\n" +
             "value = 9527\n";
 
+
     @Bean(name = GLOBAL_NACOS_PROPERTIES_BEAN_NAME)
     public Properties globalNacosProperties() {
         Properties properties = new Properties();

--- a/nacos-spring-context/src/test/java/com/alibaba/nacos/spring/test/TestOrder.java
+++ b/nacos-spring-context/src/test/java/com/alibaba/nacos/spring/test/TestOrder.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.nacos.spring.test;
+
+import com.alibaba.nacos.api.config.annotation.NacosConfigurationProperties;
+
+import java.util.Map;
+
+import static com.alibaba.nacos.spring.test.MockNacosServiceFactory.DATA_ID;
+import static com.alibaba.nacos.spring.test.MockNacosServiceFactory.GROUP_ID;
+
+/**
+ * @author <a href="mailto:liaochunyhm@live.com">liaochuntao</a>
+ * @since
+ */
+@NacosConfigurationProperties(dataId = DATA_ID, groupId = GROUP_ID, ignoreNestedProperties = true,
+        autoRefreshed = true, yaml = true)
+public class TestOrder {
+
+    private String userName;
+    private String address;
+    private String phone;
+    private String fOrderCreateTime;
+    private String userUUID;
+    private String fOrderCost;
+    private String fOrderCostFake;
+    private String fOrderMailCost;
+    private String fOrderSubPrice;
+    private String wxFdOrders;
+    private Map<String, String> fdOrderFoodId;
+    private String addId;
+
+    public String getUserName() {
+        return userName;
+    }
+
+    public void setUserName(String userName) {
+        this.userName = userName;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    public String getPhone() {
+        return phone;
+    }
+
+    public void setPhone(String phone) {
+        this.phone = phone;
+    }
+
+    public String getfOrderCreateTime() {
+        return fOrderCreateTime;
+    }
+
+    public void setfOrderCreateTime(String fOrderCreateTime) {
+        this.fOrderCreateTime = fOrderCreateTime;
+    }
+
+    public String getUserUUID() {
+        return userUUID;
+    }
+
+    public void setUserUUID(String userUUID) {
+        this.userUUID = userUUID;
+    }
+
+    public String getfOrderCost() {
+        return fOrderCost;
+    }
+
+    public void setfOrderCost(String fOrderCost) {
+        this.fOrderCost = fOrderCost;
+    }
+
+    public String getfOrderCostFake() {
+        return fOrderCostFake;
+    }
+
+    public void setfOrderCostFake(String fOrderCostFake) {
+        this.fOrderCostFake = fOrderCostFake;
+    }
+
+    public String getfOrderMailCost() {
+        return fOrderMailCost;
+    }
+
+    public void setfOrderMailCost(String fOrderMailCost) {
+        this.fOrderMailCost = fOrderMailCost;
+    }
+
+    public String getfOrderSubPrice() {
+        return fOrderSubPrice;
+    }
+
+    public void setfOrderSubPrice(String fOrderSubPrice) {
+        this.fOrderSubPrice = fOrderSubPrice;
+    }
+
+    public String getWxFdOrders() {
+        return wxFdOrders;
+    }
+
+    public void setWxFdOrders(String wxFdOrders) {
+        this.wxFdOrders = wxFdOrders;
+    }
+
+    public Map<String, String> getFdOrderFoodId() {
+        return fdOrderFoodId;
+    }
+
+    public void setFdOrderFoodId(Map<String, String> fdOrderFoodId) {
+        this.fdOrderFoodId = fdOrderFoodId;
+    }
+
+    public String getAddId() {
+        return addId;
+    }
+
+    public void setAddId(String addId) {
+        this.addId = addId;
+    }
+
+    @Override
+    public String toString() {
+        return "TestOrder{" +
+                "userName='" + userName + '\'' +
+                ", address='" + address + '\'' +
+                ", phone='" + phone + '\'' +
+                ", fOrderCreateTime='" + fOrderCreateTime + '\'' +
+                ", userUUID='" + userUUID + '\'' +
+                ", fOrderCost='" + fOrderCost + '\'' +
+                ", fOrderCostFake='" + fOrderCostFake + '\'' +
+                ", fOrderMailCost='" + fOrderMailCost + '\'' +
+                ", fOrderSubPrice='" + fOrderSubPrice + '\'' +
+                ", wxFdOrders='" + wxFdOrders + '\'' +
+                ", fdOrderFoodId=" + fdOrderFoodId +
+                ", addId='" + addId + '\'' +
+                '}';
+    }
+}

--- a/nacos-spring-context/src/test/java/com/alibaba/nacos/spring/test/XmlApp2.java
+++ b/nacos-spring-context/src/test/java/com/alibaba/nacos/spring/test/XmlApp2.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.nacos.spring.test;
+
+import com.alibaba.nacos.api.config.annotation.NacosConfigurationProperties;
+
+import java.util.List;
+
+import static com.alibaba.nacos.api.common.Constants.DEFAULT_GROUP;
+
+/**
+ * @author <a href="mailto:liaochunyhm@live.com">liaochuntao</a>
+ * @since
+ */
+@NacosConfigurationProperties(dataId = "xml_app", groupId = DEFAULT_GROUP, yaml = true, autoRefreshed = true, ignoreNestedProperties = true)
+public class XmlApp2 {
+
+    public static final String DATA_ID_XML = "xml_app";
+
+    private List<Student> students;
+
+    public List<Student> getStudents() {
+        return students;
+    }
+
+    public void setStudents(List<Student> students) {
+        this.students = students;
+    }
+
+    @Override
+    public String toString() {
+        return "XmlApp2{" +
+                "students=" + students +
+                '}';
+    }
+
+    public static class Student {
+
+        private String name;
+        private String num;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getNum() {
+            return num;
+        }
+
+        public void setNum(String num) {
+            this.num = num;
+        }
+
+        @Override
+        public String toString() {
+            return "Student{" +
+                    "name='" + name + '\'' +
+                    ", num='" + num + '\'' +
+                    '}';
+        }
+    }
+
+}

--- a/nacos-spring-context/src/test/java/com/alibaba/nacos/spring/util/NacosBeanUtilsTest.java
+++ b/nacos-spring-context/src/test/java/com/alibaba/nacos/spring/util/NacosBeanUtilsTest.java
@@ -16,8 +16,10 @@
  */
 package com.alibaba.nacos.spring.util;
 
+import com.alibaba.nacos.spring.factory.ApplicationContextHolder;
 import com.alibaba.nacos.spring.factory.CacheableEventPublishingNacosServiceFactory;
 import com.alibaba.nacos.spring.factory.NacosServiceFactory;
+import com.alibaba.nacos.spring.test.TestApplicationHolder;
 import com.alibaba.nacos.spring.test.TestConfiguration;
 import org.junit.Assert;
 import org.junit.Test;
@@ -26,6 +28,7 @@ import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -41,7 +44,7 @@ import static com.alibaba.nacos.spring.util.NacosBeanUtils.isBeanDefinitionPrese
  * @since 0.1.0
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(classes = TestConfiguration.class)
+@ContextConfiguration(classes = {TestConfiguration.class, TestApplicationHolder.class})
 public class NacosBeanUtilsTest {
 
     @Autowired
@@ -52,14 +55,14 @@ public class NacosBeanUtilsTest {
     private Properties globalProperties;
 
     @Autowired
-    @Qualifier(CacheableEventPublishingNacosServiceFactory.BEAN_NAME)
-    private NacosServiceFactory nacosServiceFactory;
+    private ApplicationContextHolder applicationContextHolder;
 
     @Test
     public void testBeans() {
 
         Assert.assertEquals(globalProperties, NacosBeanUtils.getGlobalPropertiesBean(beanFactory));
-        Assert.assertEquals(nacosServiceFactory, NacosBeanUtils.getNacosServiceFactoryBean(beanFactory));
+        Assert.assertEquals(applicationContextHolder, NacosBeanUtils.getApplicationContextHolder(beanFactory));
+        Assert.assertNotNull(NacosBeanUtils.getNacosServiceFactoryBean(beanFactory));
 
     }
 
@@ -69,8 +72,6 @@ public class NacosBeanUtilsTest {
         BeanDefinitionRegistry registry = (BeanDefinitionRegistry) beanFactory;
 
         Assert.assertTrue(isBeanDefinitionPresent(registry, GLOBAL_NACOS_PROPERTIES_BEAN_NAME, Properties.class));
-        Assert.assertTrue(isBeanDefinitionPresent(registry, CacheableEventPublishingNacosServiceFactory.BEAN_NAME, NacosServiceFactory.class));
-        Assert.assertTrue(isBeanDefinitionPresent(registry, CacheableEventPublishingNacosServiceFactory.BEAN_NAME, NacosServiceFactory.class));
 
     }
 

--- a/nacos-spring-samples/nacos-spring-webmvc-sample/src/main/java/com/alibaba/nacos/samples/spring/config/PojoNacosConfigConverter.java
+++ b/nacos-spring-samples/nacos-spring-webmvc-sample/src/main/java/com/alibaba/nacos/samples/spring/config/PojoNacosConfigConverter.java
@@ -18,7 +18,7 @@ package com.alibaba.nacos.samples.spring.config;
 
 import com.alibaba.nacos.api.config.convert.NacosConfigConverter;
 import com.alibaba.nacos.samples.spring.domain.Pojo;
-import org.codehaus.jackson.map.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 

--- a/nacos-spring-samples/nacos-spring-webmvc-sample/src/main/java/com/alibaba/nacos/samples/spring/listener/PojoNacosConfigListener.java
+++ b/nacos-spring-samples/nacos-spring-webmvc-sample/src/main/java/com/alibaba/nacos/samples/spring/listener/PojoNacosConfigListener.java
@@ -22,7 +22,7 @@ import com.alibaba.nacos.api.config.annotation.NacosConfigListener;
 import com.alibaba.nacos.samples.spring.NacosConfiguration;
 import com.alibaba.nacos.samples.spring.config.PojoNacosConfigConverter;
 import com.alibaba.nacos.samples.spring.domain.Pojo;
-import org.codehaus.jackson.map.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Configuration;

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <sonar.jacoco.itReportPath>${project.basedir}/../test/target/jacoco-it.exec</sonar.jacoco.itReportPath>
         <sonar.exclusions>file:**/generated-sources/**,**/test/**</sonar.exclusions>
         <!-- Nacos -->
-        <nacos.version>0.2.1-RC1</nacos.version>
+        <nacos.version>1.0.1</nacos.version>
         <!-- Spring -->
         <spring.framework.version>3.2.18.RELEASE</spring.framework.version>
         <!-- Servlet -->

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,8 @@
         <nacos.version>1.0.1</nacos.version>
         <!-- Spring -->
         <spring.framework.version>3.2.18.RELEASE</spring.framework.version>
+        <!--snake-yaml-->
+        <snake.yaml.version>1.19</snake.yaml.version>
         <!-- Servlet -->
         <servlet-api.version>3.0.1</servlet-api.version>
     </properties>
@@ -107,6 +109,12 @@
                 <groupId>com.alibaba.nacos</groupId>
                 <artifactId>nacos-client</artifactId>
                 <version>${nacos.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.yaml</groupId>
+                <artifactId>snakeyaml</artifactId>
+                <version>${snake.yaml.version}</version>
             </dependency>
 
             <!-- Spring Framework -->


### PR DESCRIPTION
## Feature

Json yaml XML properties configuration file type parsing is supported

## See Here

默认实现性能，JSON，YAML，XML四种配置类型文件解析，如果用户存在扩展需求，仅仅需要shiyongSPI机制，实现ConfigParse接口即可

`com.alibaba.nacos.spring.util.parse.DefaultJsonConfigParse`
`com.alibaba.nacos.spring.util.parse.DefaultPropertiesConfigParse`
`com.alibaba.nacos.spring.util.parse.DefaultXmlConfigParse`
`com.alibaba.nacos.spring.util.parse.DefaultYamlConfigParse`