### PR TITLE
修复在多个/多级SpringContext并存环境下,EventPublishingConfigService发送事件混乱，引发后续依赖事…

### DIFF
--- a/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/util/NacosBeanUtils.java
+++ b/nacos-spring-context/src/main/java/com/alibaba/nacos/spring/util/NacosBeanUtils.java
@@ -401,6 +401,14 @@ public abstract class NacosBeanUtils {
 		registerConfigServiceBeanBuilder(registry);
 
 		registerLoggingNacosConfigMetadataEventListener(registry);
+
+		registerCacheableEventPublishingNacosServiceFactory(registry,beanFactory);
+	}
+
+	private static void registerCacheableEventPublishingNacosServiceFactory(BeanDefinitionRegistry registry, BeanFactory beanFactory) {
+		registerInfrastructureBeanIfAbsent(registry,
+				NacosServiceFactory.BEAN_NAME,
+				CacheableEventPublishingNacosServiceFactory.class);
 	}
 
 	/**
@@ -491,21 +499,8 @@ public abstract class NacosBeanUtils {
 	 */
 	public static NacosServiceFactory getNacosServiceFactoryBean(BeanFactory beanFactory)
 			throws NoSuchBeanDefinitionException {
-		if (null == beanFactory) {
-			return getNacosServiceFactoryBean();
-		}
-		ApplicationContextHolder applicationContextHolder = getApplicationContextHolder(
-				beanFactory);
-		CacheableEventPublishingNacosServiceFactory nacosServiceFactory = CacheableEventPublishingNacosServiceFactory
-				.getSingleton();
-		nacosServiceFactory
-				.setApplicationContext(applicationContextHolder.getApplicationContext());
-		return nacosServiceFactory;
-	}
-
-	public static NacosServiceFactory getNacosServiceFactoryBean()
-			throws NoSuchBeanDefinitionException {
-		return CacheableEventPublishingNacosServiceFactory.getSingleton();
+		return  beanFactory.getBean(NacosServiceFactory.BEAN_NAME,
+				NacosServiceFactory.class);
 	}
 
 	public static ApplicationContextHolder getApplicationContextHolder(

--- a/nacos-spring-context/src/test/java/com/alibaba/nacos/spring/context/annotation/config/NacosPropertySourcePostProcessorTest.java
+++ b/nacos-spring-context/src/test/java/com/alibaba/nacos/spring/context/annotation/config/NacosPropertySourcePostProcessorTest.java
@@ -28,11 +28,14 @@ import static org.springframework.core.env.StandardEnvironment.SYSTEM_PROPERTIES
 import java.util.HashMap;
 import java.util.Map;
 
+import com.alibaba.nacos.spring.factory.CacheableEventPublishingNacosServiceFactory;
+import com.alibaba.nacos.spring.factory.NacosServiceFactory;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
@@ -84,6 +87,8 @@ public class NacosPropertySourcePostProcessorTest
 			+ "PATH = /My/Path";
 	@NacosInjected
 	private ConfigService configService;
+	@Autowired
+	private NacosServiceFactory nacosServiceFactory;
 
 	@Override
 	public void init(EmbeddedNacosHttpServer httpServer) {
@@ -179,7 +184,7 @@ public class NacosPropertySourcePostProcessorTest
 		configService.publishConfig(dataId, groupId, content);
 
 		beanFactory.registerSingleton(CONFIG_SERVICE_BEAN_NAME, configService);
-
+		beanFactory.registerSingleton(NacosServiceFactory.BEAN_NAME,nacosServiceFactory);
 		context.register(AnnotationNacosInjectedBeanPostProcessor.class,
 				NacosPropertySourcePostProcessor.class, ConfigServiceBeanBuilder.class,
 				AnnotationNacosPropertySourceBuilder.class, TestConfiguration.class,


### PR DESCRIPTION
…件机制的系列问题，如@NacosValue注解无法解析到最新值

  Please do not create a Pull Request without creating an issue first.

## What is the purpose of the change

修复在多个/多级SpringContext并存环境下,EventPublishingConfigService发送事件混乱，引发后续依赖事件机制的系列问题，如@NacosValue注解无法解析到最新值

## Brief changelog



## Verifying this change

1. 应用可能出现多个SpringContext, 如一般的SpringMvc项目，包含SpringMvc容器和Root容器，SpringMvc容器的parent指向Root容器，它们是上级层级关系
2.CacheableEventPublishingNacosServiceFactory拥有字段(ConfigurableApplicationContext context),它能作为单例使用的前提条件是，应用的只有存在一个容器单独使用Nacos，而多个SpringContext同时使用Nacos，就可能引发创建的ConfigService是（上一个SpringContext创建的，被缓存）
3.基于以上，此PR删除CacheableEventPublishingNacosServiceFactory.getSingleton()获取单例的方法，将CacheableEventPublishingNacosServiceFactory对象的创建关联到容器

Follow this checklist to help us incorporate your contribution quickly and easily:

* [ ] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [ ] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [ ] Run `mvn -B clean package apache-rat:check findbugs:findbugs -Dmaven.test.skip=true` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.

